### PR TITLE
#180 redux

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,7 +7,7 @@
 * Jorge Landivar @docmerlin - tests, bug finding and documentation
 * Matoko Ito @ynqa - tests, documentation and bug finding
 * Siquus (@siquus) - TensorDot, contraction
-* Tan Chen(@tantanchen) - Bug finding and documentation
+* Tan Chen (@tantanchen) - Bug finding and documentation
 
 
 # Contributors
@@ -20,7 +20,7 @@
 * James Michael DuPont | @h4ck3rm1k3
 * Jorge Landivar | @docmerlin
 * Yuanlin Lian | @alienchow
-
+* Bart Fokker | @barthr
 
 
 For more contributors, check out the [github contributors page](https://github.com/gorgonia/graphs/contributors)

--- a/gorgonia.go
+++ b/gorgonia.go
@@ -103,8 +103,20 @@ func NewConstant(v interface{}, opts ...NodeConsOpt) *Node {
 		panic(fmt.Sprintf("HELP. Op: %v, t: %v", op, t))
 	}
 
-	consOpts := []NodeConsOpt{WithOp(op), WithType(t), WithName(name), WithShape(s...), WithValue(val)}
+	dummy := borrowNode()
+	consOpts := []NodeConsOpt{WithOp(op), WithType(t), WithShape(s...), WithValue(val)}
 	consOpts = append(consOpts, opts...)
+	for i := range opts {
+		opts[i](dummy)
+	}
+	if dummy.name == "" {
+		name = fmt.Sprintf("%v", v)
+	} else {
+		name = dummy.name
+	}
+	returnNode(dummy)
+
+	consOpts = append(consOpts, WithName(name))
 	return newNode(consOpts...)
 }
 

--- a/gorgonia.go
+++ b/gorgonia.go
@@ -86,7 +86,6 @@ func NewConstant(v interface{}, opts ...NodeConsOpt) *Node {
 	var s tensor.Shape
 	var val Value
 
-	name = fmt.Sprintf("%v", v)
 	val, t, _, err := anyToValue(v)
 	if err != nil {
 		panic(err)

--- a/graph.go
+++ b/graph.go
@@ -138,7 +138,7 @@ func (g *ExprGraph) AddNode(n *Node) (retVal *Node) {
 	// check for node with the same name in the graph
 	// we don't update the graph if this is the case
 	for _, node := range g.constants {
-		if node.name == n.name {
+		if node.name == n.name && n.isConstant() {
 			return node
 		}
 	}

--- a/graph.go
+++ b/graph.go
@@ -135,7 +135,13 @@ func (g *ExprGraph) AddNode(n *Node) (retVal *Node) {
 			g.to[retVal] = nil
 		}
 	}()
-
+	// check for node with the same name in the graph
+	// we don't update the graph if this is the case
+	for _, node := range g.constants {
+		if node.name == n.name {
+			return node
+		}
+	}
 	hash := n.Hashcode()
 	if existing, ok := g.byHash[hash]; ok {
 		if existing == nil {

--- a/node.go
+++ b/node.go
@@ -201,10 +201,6 @@ func newNode(opts ...NodeConsOpt) *Node {
 	}
 	n.fix()
 
-	if n.name == "" {
-		panic(fmt.Sprintf("Node %v, failed constructing node. Name field is empty", n))
-	}
-
 	incrNN()
 	return n
 }

--- a/node.go
+++ b/node.go
@@ -201,6 +201,10 @@ func newNode(opts ...NodeConsOpt) *Node {
 	}
 	n.fix()
 
+	if n.name == "" {
+		panic(fmt.Sprintf("Node %v, failed constructing node. Name field is empty", n))
+	}
+
 	incrNN()
 	return n
 }

--- a/node.go
+++ b/node.go
@@ -116,9 +116,7 @@ func In(g *ExprGraph) NodeConsOpt {
 // WithName is a node construction option that gives the *Node the provided name. This is especially useful in debugging graphs.
 func WithName(name string) NodeConsOpt {
 	f := func(n *Node) {
-		if name != "" {
-			n.name = name
-		}
+		n.name = name
 	}
 	return f
 }

--- a/node.go
+++ b/node.go
@@ -116,7 +116,9 @@ func In(g *ExprGraph) NodeConsOpt {
 // WithName is a node construction option that gives the *Node the provided name. This is especially useful in debugging graphs.
 func WithName(name string) NodeConsOpt {
 	f := func(n *Node) {
-		n.name = name
+		if name != "" {
+			n.name = name
+		}
 	}
 	return f
 }


### PR DESCRIPTION
Fixes #177 by adding an optional naming capability - by default fmt.Sprintf will be used but if a name is passed in, then it will be used as the identifier for the constant.