### PR TITLE
Fixed a tiny bug in UnbindNonInputs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ branches:
   only:
     - master
 go:
-  - 1.6.x
-  - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
   - tip
 
 env:

--- a/graph.go
+++ b/graph.go
@@ -270,7 +270,7 @@ func (g *ExprGraph) UnbindAll() {
 // UnbindAllNonInputs unbinds all the values from nodes that aren't input nodes
 func (g *ExprGraph) UnbindAllNonInputs() {
 	for _, n := range g.all {
-		if n.isInput() {
+		if n.isInput() || n.isConstant() {
 			continue
 		}
 		n.unbind()


### PR DESCRIPTION
Removed pre-go1.8 from travis because Gonum no longer supports pre1.8