### PR TITLE
Use go1.10's default gopath if can't find a gopath

### DIFF
--- a/cmd/cudagen/main.go
+++ b/cmd/cudagen/main.go
@@ -91,7 +91,7 @@ func main() {
 
 	gopath := os.Getenv("GOPATH")
 	if gopath = "" {
-		gopath = path.Join(os.Getenv("HOME"),"go")
+		gopath = path.Join(os.Getenv("HOME"), "go")
 	}
 	gorgoniaLoc := path.Join(gopath, "src/gorgonia.org/gorgonia")
 	cuLoc := path.Join(gorgoniaLoc, "cuda modules/src")

--- a/cmd/cudagen/main.go
+++ b/cmd/cudagen/main.go
@@ -90,6 +90,9 @@ func main() {
 	}
 
 	gopath := os.Getenv("GOPATH")
+	if gopath = "" {
+		gopath = path.Join(os.Getenv("HOME"),"go")
+	}
 	gorgoniaLoc := path.Join(gopath, "src/gorgonia.org/gorgonia")
 	cuLoc := path.Join(gorgoniaLoc, "cuda modules/src")
 	ptxLoc := path.Join(gorgoniaLoc, "cuda modules/target")


### PR DESCRIPTION
Use go1.10's default gopath if can't find a gopath