### PR TITLE
Remove waring of dep, update Gonum & minor fix in example

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,14 @@
 
 [[projects]]
   name = "github.com/awalterschulze/gographviz"
-  packages = [".","ast","internal/errors","internal/lexer","internal/parser","internal/token"]
+  packages = [
+    ".",
+    "ast",
+    "internal/errors",
+    "internal/lexer",
+    "internal/parser",
+    "internal/token"
+  ]
   revision = "c84395e536e1a1199093a4e6253d1bee99e4cd2a"
   version = "v2.0"
 
@@ -100,13 +107,35 @@
 [[projects]]
   branch = "master"
   name = "gonum.org/v1/gonum"
-  packages = ["blas","blas/blas64","blas/gonum","floats","graph","graph/internal/linear","graph/internal/ordered","graph/internal/set","graph/topo","graph/traverse","internal/asm/c128","internal/asm/f32","internal/asm/f64","internal/math32","lapack","lapack/gonum","lapack/lapack64","mat"]
-  revision = "f818f8f7a9e59de54e475b747a3dc9c86ed141f1"
+  packages = [
+    "blas",
+    "blas/blas64",
+    "blas/gonum",
+    "floats",
+    "graph",
+    "graph/internal/linear",
+    "graph/internal/ordered",
+    "graph/internal/set",
+    "graph/topo",
+    "graph/traverse",
+    "internal/asm/c128",
+    "internal/asm/f32",
+    "internal/asm/f64",
+    "internal/math32",
+    "lapack",
+    "lapack/gonum",
+    "lapack/lapack64",
+    "mat"
+  ]
+  revision = "e9e56344e335b77c52738092530a60fd12db0351"
 
 [[projects]]
   branch = "master"
   name = "gonum.org/v1/netlib"
-  packages = ["blas/netlib","internal/binding"]
+  packages = [
+    "blas/netlib",
+    "internal/binding"
+  ]
   revision = "d22599e22c25311208d69b30773390fc4d359d1f"
 
 [[projects]]
@@ -123,7 +152,11 @@
 
 [[projects]]
   name = "gorgonia.org/tensor"
-  packages = [".","internal/execution","internal/storage"]
+  packages = [
+    ".",
+    "internal/execution",
+    "internal/storage"
+  ]
   revision = "2ab2564f998fe504b94a1679c1c95277cdedea47"
   version = "v0.8.1"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,14 +39,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "gorgonia.org/vecf32"
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/chewxy/vecf64"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/leesper/go_rng"
 
 [[constraint]]
@@ -60,10 +52,6 @@
 [[constraint]]
   branch = "master"
   name = "github.com/xtgo/set"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/tools"
 
 [[constraint]]
   branch = "master"

--- a/examples/convnet/main.go
+++ b/examples/convnet/main.go
@@ -278,7 +278,7 @@ func main() {
 				log.Fatal("Unable to slice y")
 			}
 			if err = xVal.(*tensor.Dense).Reshape(bs, 1, 28, 28); err != nil {
-				log.Fatal("Unable to reshape %v", err)
+				log.Fatalf("Unable to reshape %v", err)
 			}
 
 			gorgonia.Let(x, xVal)


### PR DESCRIPTION
To wrap was more thorough commented in commit messages:

1. Remove warning in deps https://github.com/gorgonia/gorgonia/issues/214
2. Updated Gonum in Gopkg ([why not despite of _vgo_ is coming?[(https://github.com/gorgonia/gorgonia/issues/213#issuecomment-401522088))
3. Minor fix in one of the examples

I believe that _2_, is good, although _vgo_ is coming, however if you prefer not to and you want to keep the rest of the commits, let me know and I will drop such commit.

I could make a comment about _1_, before making the change, however, because of the minor change, it was easier to make a commit rather than trying to explain by words on the issue; however, I know that you may prefer other thing, so don't hesitate to comment what to do or reject such commit.