### PR TITLE
use a sync.Map instead of a map for dimSizerPool to prevent race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ branches:
   only:
     - master
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 
 env:


### PR DESCRIPTION
All of the tests in onnx can run in parallel. 

In this case, every subtest creates a new `ExprGraph`. The problem is that the `dimSizerPool` is not safe for concurrent use (as it is a map) and running several tests in parallel leads to a race condition.
This PR replaces the `map` by a `sync.Map`.

This patch removes the race condition but may have an impact on the performances.