### PR TITLE
Maxpool ceilmode

### DIFF
--- a/known_issues_test.go
+++ b/known_issues_test.go
@@ -129,7 +129,7 @@ func TestIssue273_maxpool_pads(t *testing.T) {
 			48, 49, 49, 49, 45, 46, 47, 48, 49, 49, 49, 45, 46, 47, 48, 49, 49, 49,
 		}))
 
-	y, err := MaxPool2D(x, []int{3, 3}, []int{2, 2}, []int{1, 1})
+	y, err := MaxPool2D(x, []int{3, 3}, []int{2, 2}, []int{1, 1}, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nn.go
+++ b/nn.go
@@ -98,6 +98,60 @@ func Dropout(x *Node, prob float64) (retVal *Node, err error) {
 	return HadamardDiv(retVal, c)
 }
 
+// LeakyRelu returns a node whose underlying value is:
+//   f(x) = alpha * x if x < 0
+//   f(x) = x for x >= 0
+// applied elementwise.
+func LeakyRelu(x *Node, alpha float64) (*Node, error) {
+	var zero *Node
+	var dt tensor.Dtype
+	var err error
+	var alphaN *Node
+
+	// which zero to use?
+	if dt, err = dtypeOf(x.t); err != nil {
+		return nil, errors.Wrap(err, dtypeOfFail)
+	}
+	switch dt {
+	case Float64:
+		zero = zerof64
+		alphaN = NewConstant(alpha)
+	case Float32:
+		zero = zerof32
+		alphaN = NewConstant(float32(alpha))
+	default:
+		return nil, errors.Errorf(nyiFail, "ReLu", dt)
+	}
+
+	gteZeroOp := newElemBinOp(gteOpType, x, zero)
+	gteZeroOp.retSame = true
+
+	xGteZeroCmp, err := ApplyOp(gteZeroOp, x, zero)
+	if err != nil {
+		return nil, errors.Wrap(err, applyOpFail)
+	}
+	ltZeroOp := newElemBinOp(ltOpType, x, zero)
+	ltZeroOp.retSame = true
+
+	xLtZeroCmp, err := ApplyOp(ltZeroOp, x, zero)
+	if err != nil {
+		return nil, errors.Wrap(err, applyOpFail)
+	}
+	xGteZero, err := HadamardProd(x, xGteZeroCmp)
+	if err != nil {
+		return nil, errors.Wrap(err, applyOpFail)
+	}
+	xLtZero, err := HadamardProd(x, xLtZeroCmp)
+	if err != nil {
+		return nil, errors.Wrap(err, applyOpFail)
+	}
+	xLtZeroAlpha, err := HadamardProd(xLtZero, alphaN)
+	if err != nil {
+		return nil, errors.Wrap(err, applyOpFail)
+	}
+	return Add(xGteZero, xLtZeroAlpha)
+}
+
 // Rectify is a convenience function for creating rectified linear units activation functions.
 // This function uses >=, which is the canonical version. If you want to use >, you can create
 // your own by just following this.
@@ -250,7 +304,7 @@ func Conv1d(in, filter *Node, kernel, pad, stride, dilation int) (*Node, error) 
 	return Conv2d(in, filter, tensor.Shape{1, kernel}, []int{0, pad}, []int{1, stride}, []int{1, dilation})
 }
 
-func MaxPool2D(x *Node, kernel tensor.Shape, pad, stride []int) (*Node, error) {
+func MaxPool2D(x *Node, kernel tensor.Shape, pad, stride []int, ceilMode bool) (*Node, error) {
 	xShape := x.Shape()
 	h, w := xShape[2], xShape[3]
 	kh, kw := kernel[0], kernel[1]
@@ -274,12 +328,12 @@ func MaxPool2D(x *Node, kernel tensor.Shape, pad, stride []int) (*Node, error) {
 		return nil, errors.New("Impossible width/kernel/pad combination")
 	}
 
-	op := newMaxPoolOp(xShape, kernel, pad, stride)
+	op := newMaxPoolOp(xShape, kernel, pad, stride, ceilMode)
 	return ApplyOp(op, x)
 }
 
-func MaxPool1D(x *Node, kernel, pad, stride int) (*Node, error) {
-	return MaxPool2D(x, tensor.Shape{1, kernel}, []int{0, pad}, []int{1, stride})
+func MaxPool1D(x *Node, kernel, pad, stride int, ceilMode bool) (*Node, error) {
+	return MaxPool2D(x, tensor.Shape{1, kernel}, []int{0, pad}, []int{1, stride}, ceilMode)
 }
 
 func BatchNorm(x, scale, bias *Node, momentum, epsilon float64) (retVal, γ, β *Node, op *BatchNormOp, err error) {

--- a/utils.go
+++ b/utils.go
@@ -256,8 +256,22 @@ func minInt(a, b int) int {
 	return b
 }
 
+func floorDivInt(a, b int) int {
+	if a%b == 0 {
+		return a / b
+	}
+
+	div := a / b
+	if a < 0 && b > 0 || a > 0 && b < 0 {
+		return div - 1
+	}
+	return div
+}
 func ceilDivInt(a, b int) int {
-	return (a + b - 1) / b
+	if a%b == 0 {
+		return a / b
+	}
+	return floorDivInt(a, b) + 1
 }
 
 func simpleHash(op hashWriter) uint32 {

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,56 @@
+package gorgonia
+
+import "testing"
+
+var divIntegerTests = []struct {
+	a     int
+	b     int
+	floor int
+	ceil  int
+}{
+	{
+		a:     -2,
+		b:     2,
+		floor: -1,
+		ceil:  -1,
+	},
+	{
+		a:     2,
+		b:     2,
+		floor: 1,
+		ceil:  1,
+	},
+	{
+		a:     5,
+		b:     2,
+		floor: 2,
+		ceil:  3,
+	},
+	{
+		a:     -21,
+		b:     10,
+		floor: -3,
+		ceil:  -2,
+	},
+	{
+		a:     29,
+		b:     10,
+		floor: 2,
+		ceil:  3,
+	},
+}
+
+func TestCeilDivInt(t *testing.T) {
+	for _, tst := range divIntegerTests {
+		if ceilDivInt(tst.a, tst.b) != tst.ceil {
+			t.Fatalf("test %v failed for ceil division (result %v)", tst, ceilDivInt(tst.a, tst.b))
+		}
+	}
+}
+func TestFloorDivInt(t *testing.T) {
+	for _, tst := range divIntegerTests {
+		if floorDivInt(tst.a, tst.b) != tst.floor {
+			t.Fatalf("test %v failed for floor division (result %v)", tst, floorDivInt(tst.a, tst.b))
+		}
+	}
+}


### PR DESCRIPTION
**TL;DR:** This PR is a draft to open the discussion about a possibility to break the API for the Maxpool operator to add a "ceil mode".

**Longer:** 

From version 1.5, onnx supports a "ceil mode" attribute that has an impact on the calculus of the output shape on the Maxpool operator. (see [this disccusion](https://github.com/onnx/onnx/issues/549) for more info).

By now, I did not find any model that is using this mode, nevertheless, I've implemented a basic implementation to do different tests (one again **I am only using this branch for testing purpose**.)

The problem is that it breaks the API by adding a new attribute to the `MaxPool2D` function; another option would be to keep this function as-is and silently set the `ceilMode` to false and to create a new transition function `MaxPool2DCeil` but it do not really like this idea.

WDYT?
