### PR TITLE
Reshape optim

### DIFF
--- a/benchmark_operations_test.go
+++ b/benchmark_operations_test.go
@@ -1,0 +1,36 @@
+package gorgonia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorgonia.org/tensor"
+)
+
+func BenchmarkReshape_Dense(b *testing.B) {
+	for _, rst := range reshapeTests {
+		b.Run(rst.testName, func(b *testing.B) {
+			g := NewGraph()
+			tT := tensor.New(tensor.Of(tensor.Float64), tensor.WithShape(rst.input.Clone()...))
+			T := NodeFromAny(g, tT)
+			for i := 0; i < b.N; i++ {
+				T2, err := Reshape(T, rst.to.Clone())
+				switch {
+				case rst.err && err == nil:
+					b.Fatalf("Expected Error when testing %v", rst)
+				case rst.err:
+					continue
+				case err != nil:
+					b.Fatal(err)
+				default:
+					assert.True(b, rst.output.Eq(T2.Shape()), "expected both to be the same")
+				}
+			}
+			m := NewTapeMachine(g)
+			if err := m.RunAll(); err != nil {
+				b.Fatal(err)
+			}
+
+		})
+	}
+}

--- a/op_tensor.go
+++ b/op_tensor.go
@@ -1142,9 +1142,19 @@ func (op reshapeOp) Do(vals ...Value) (Value, error) {
 	}
 	var val Value
 	var err error
-	if val, err = CloneValue(vals[0]); err != nil {
-		return nil, errors.Wrapf(err, cloneFail, vals[0])
+	switch vals[0].(type) {
+	case tensor.Tensor:
+		if v, ok := vals[0].(*tensor.Dense); ok {
+			val = v.ShallowClone()
+		} else {
+			if val, err = CloneValue(vals[0]); err != nil {
+				return nil, errors.Wrapf(err, cloneFail, vals[0])
+			}
+		}
+	default:
+		return nil, errors.Errorf(nyiTypeFail, "reshape.Do", "Non tensor")
 	}
+
 	if !val.Shape().Eq(op.from) {
 		return nil, errors.Errorf("Shape mismatch. Input shape is %v. Expected %v", val.Shape(), op.from)
 	}

--- a/operations_test.go
+++ b/operations_test.go
@@ -900,6 +900,7 @@ var reshapeTests = []struct {
 	err      bool
 }{
 	{"simple", tensor.Shape{2, 2}, tensor.Shape{4}, tensor.Shape{4}, false},
+	{"simple big tensor", tensor.Shape{200, 200}, tensor.Shape{200 * 200}, tensor.Shape{200 * 200}, false},
 	{"negative dim1 1", tensor.Shape{3, 2}, tensor.Shape{6, -1}, tensor.Shape{6, 1}, false},
 	{"negative dim1 2", tensor.Shape{3, 2}, tensor.Shape{2, -1}, tensor.Shape{2, 3}, false},
 	{"negative dim0 1", tensor.Shape{3, 2}, tensor.Shape{-1, 3}, tensor.Shape{2, 3}, false},


### PR DESCRIPTION
This PR is related to #296 

* the `reshapeOP` uses a `ShallowClone` method of the value if it's a `*tensor.Dense`.

* the `OverwriteInput` method returns `-1` because it does not touch the backend values and creates a new entity to work on.