### PR TITLE
feat: dot representation of a graph as an external package

### DIFF
--- a/encoding/constants.go
+++ b/encoding/constants.go
@@ -1,0 +1,19 @@
+package encoding
+
+// Cluster represent a group of nodes that are similars
+// It is used for the grapviz generation
+
+const (
+	// UndefinedCluster ...
+	UndefinedCluster GroupID = iota
+	// ExprGraphCluster is the default cluster
+	ExprGraphCluster
+	// ConstantCluster is the group of nodes that represents constants
+	ConstantCluster
+	// InputCluster is the group of nodes that are expecting values
+	InputCluster
+	// GradientCluster ...
+	GradientCluster
+	// StrayCluster ...
+	StrayCluster
+)

--- a/encoding/dot/constantgraph.go
+++ b/encoding/dot/constantgraph.go
@@ -1,0 +1,44 @@
+package dot
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+)
+
+type constantSubGraph struct {
+	name string
+	graph.DirectedBuilder
+}
+
+func (g constantSubGraph) DOTID() string { return g.name }
+
+// DOTAttributers to specify the top-level graph attributes for the graphviz generation
+func (g constantSubGraph) DOTAttributers() (graph, node, edge encoding.Attributer) {
+	// Create a special attribute "rank" to place the input at the same level in the graph
+
+	graphAttributes := attributer{
+		encoding.Attribute{
+			Key:   "label",
+			Value: g.name,
+		},
+		encoding.Attribute{
+			Key:   "rank",
+			Value: `"max"`,
+		},
+	}
+	nodeAttributes := attributer{
+		encoding.Attribute{
+			Key:   "style",
+			Value: `"rounded,filled"`,
+		},
+		encoding.Attribute{
+			Key:   "shape",
+			Value: "record",
+		},
+		encoding.Attribute{
+			Key:   "fillcolor",
+			Value: "pink",
+		},
+	}
+	return graphAttributes, nodeAttributes, attributer{}
+}

--- a/encoding/dot/copy.go
+++ b/encoding/dot/copy.go
@@ -1,0 +1,31 @@
+package dot
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gorgonia.org/gorgonia"
+)
+
+func copyGraph(dst graph.Builder, src graph.Graph) {
+	nodes := src.Nodes()
+	for nodes.Next() {
+		current := nodes.Node().(*gorgonia.Node)
+		dst.AddNode(&node{
+			n: current,
+		})
+	}
+	nodes.Reset()
+	for nodes.Next() {
+		u := &node{
+			n: nodes.Node().(*gorgonia.Node),
+		}
+		uid := u.ID()
+		to := src.From(uid)
+		for to.Next() {
+			v := &node{
+				n: to.Node().(*gorgonia.Node),
+			}
+			dst.SetEdge(dst.NewEdge(u, v))
+			//dst.SetEdge(src.Edge(uid, v.ID()))
+		}
+	}
+}

--- a/encoding/dot/doc.go
+++ b/encoding/dot/doc.go
@@ -1,0 +1,2 @@
+// Package dot creates a graphviz compatible version of the ExprGraph
+package dot

--- a/encoding/dot/encode.go
+++ b/encoding/dot/encode.go
@@ -1,0 +1,17 @@
+package dot
+
+import (
+	gonumDot "gonum.org/v1/gonum/graph/encoding/dot"
+	"gorgonia.org/gorgonia"
+)
+
+// Marshal the graph in a dot (graphviz)
+// This methods also generates the subgraphs
+func Marshal(g *gorgonia.ExprGraph) ([]byte, error) {
+	dg, err := generateDotGraph(g)
+	if err != nil {
+		return nil, err
+	}
+
+	return gonumDot.Marshal(dg, "", "", "\t")
+}

--- a/encoding/dot/example_test.go
+++ b/encoding/dot/example_test.go
@@ -1,0 +1,25 @@
+package dot
+
+import (
+	"fmt"
+	"log"
+
+	"gorgonia.org/gorgonia"
+)
+
+func ExampleMarshal() {
+	g := gorgonia.NewGraph()
+
+	var x, y *gorgonia.Node
+	var err error
+
+	// define the expression
+	x = gorgonia.NewScalar(g, gorgonia.Float64, gorgonia.WithName("x"))
+	y = gorgonia.NewScalar(g, gorgonia.Float64, gorgonia.WithName("y"))
+	if _, err = gorgonia.Add(x, y); err != nil {
+		log.Fatal(err)
+	}
+	if b, err := Marshal(g); err == nil {
+		fmt.Println(string(b))
+	}
+}

--- a/encoding/dot/exprsubgraph.go
+++ b/encoding/dot/exprsubgraph.go
@@ -1,0 +1,56 @@
+package dot
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+)
+
+type exprSubGraph struct {
+	name string
+	graph.DirectedBuilder
+}
+
+func (g exprSubGraph) DOTID() string { return "cluster_" + g.name }
+
+// DOTAttributers to specify the top-level graph attributes for the graphviz generation
+func (g exprSubGraph) DOTAttributers() (graph, node, edge encoding.Attributer) {
+	// Create a special attribute "rank" to place the input at the same level in the graph
+
+	graphAttributes := attributer{
+		encoding.Attribute{
+			Key:   "label",
+			Value: g.name,
+		},
+		encoding.Attribute{
+			Key:   "color",
+			Value: "lightgray",
+		},
+		encoding.Attribute{
+			Key:   "style",
+			Value: "filled",
+		},
+		encoding.Attribute{
+			Key:   "nodeset",
+			Value: "0.5",
+		},
+		encoding.Attribute{
+			Key:   "ranksep",
+			Value: `"1.2 equally"`,
+		},
+	}
+	nodeAttributes := attributer{
+		encoding.Attribute{
+			Key:   "style",
+			Value: `"rounded,filled"`,
+		},
+		encoding.Attribute{
+			Key:   "fillcolor",
+			Value: "white",
+		},
+		encoding.Attribute{
+			Key:   "shape",
+			Value: "Mrecord",
+		},
+	}
+	return graphAttributes, nodeAttributes, attributer{}
+}

--- a/encoding/dot/graph.go
+++ b/encoding/dot/graph.go
@@ -1,0 +1,45 @@
+package dot
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+	gonumDot "gonum.org/v1/gonum/graph/encoding/dot"
+)
+
+// This structures handles the toplevel graph attributes
+type dotGraph struct {
+	graph.Directed
+	subs []gonumDot.Graph
+}
+
+// DOTAttributers to specify the top-level graph attributes for the graphviz generation
+func (g dotGraph) DOTAttributers() (graph, node, edge encoding.Attributer) {
+	// Create a special attribute "rank" to place the input at the same level in the graph
+
+	graphAttributes := attributer{
+		encoding.Attribute{
+			Key:   "rankdir",
+			Value: "TB",
+		},
+	}
+	nodeAttributes := attributer{
+		encoding.Attribute{
+			Key:   "style",
+			Value: "rounded",
+		},
+		encoding.Attribute{
+			Key:   "fontsize",
+			Value: "10",
+		},
+		encoding.Attribute{
+			Key:   "shape",
+			Value: "none",
+		},
+	}
+	return graphAttributes, nodeAttributes, attributer{}
+}
+
+// Structure fulfils the dot.Structurer interface.
+func (g dotGraph) Structure() []gonumDot.Graph {
+	return g.subs
+}

--- a/encoding/dot/inputsubgraph.go
+++ b/encoding/dot/inputsubgraph.go
@@ -1,0 +1,44 @@
+package dot
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+)
+
+type inputSubGraph struct {
+	name string
+	graph.DirectedBuilder
+}
+
+func (g inputSubGraph) DOTID() string { return g.name }
+
+// DOTAttributers to specify the top-level graph attributes for the graphviz generation
+func (g inputSubGraph) DOTAttributers() (graph, node, edge encoding.Attributer) {
+	// Create a special attribute "rank" to place the input at the same level in the graph
+
+	graphAttributes := attributer{
+		encoding.Attribute{
+			Key:   "label",
+			Value: g.name,
+		},
+		encoding.Attribute{
+			Key:   "rank",
+			Value: `"max"`,
+		},
+	}
+	nodeAttributes := attributer{
+		encoding.Attribute{
+			Key:   "style",
+			Value: `"rounded,filled"`,
+		},
+		encoding.Attribute{
+			Key:   "shape",
+			Value: "record",
+		},
+		encoding.Attribute{
+			Key:   "fillcolor",
+			Value: "yellow",
+		},
+	}
+	return graphAttributes, nodeAttributes, attributer{}
+}

--- a/encoding/dot/interface.go
+++ b/encoding/dot/interface.go
@@ -1,0 +1,9 @@
+package dot
+
+import gonumDot "gonum.org/v1/gonum/graph/encoding/dot"
+
+// Subgrapher is any type that can represent itself as a subgraph
+type subgrapher interface {
+	gonumDot.Graph
+	gonumDot.Attributers
+}

--- a/encoding/dot/marshal_test.go
+++ b/encoding/dot/marshal_test.go
@@ -1,0 +1,26 @@
+package dot
+
+import (
+	"testing"
+
+	"gorgonia.org/gorgonia"
+)
+
+func TestMarshal(t *testing.T) {
+	g := gorgonia.NewGraph()
+
+	var x, y *gorgonia.Node
+	var err error
+
+	// define the expression
+	x = gorgonia.NewScalar(g, gorgonia.Float64, gorgonia.WithName("x"))
+	y = gorgonia.NewScalar(g, gorgonia.Float64, gorgonia.WithName("y"))
+	if _, err = gorgonia.Add(x, y); err != nil {
+		t.Fatal(err)
+	}
+	b, err := Marshal(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = b
+}

--- a/encoding/dot/node.go
+++ b/encoding/dot/node.go
@@ -1,0 +1,51 @@
+package dot
+
+import (
+	"fmt"
+	"strings"
+
+	"gonum.org/v1/gonum/graph/encoding"
+	"gorgonia.org/gorgonia"
+)
+
+type node struct {
+	n *gorgonia.Node
+}
+
+func (n *node) ID() int64 {
+	return n.n.ID()
+}
+
+// DOTID is used for the graphviz output. It fulfils the gonum encoding interface
+func (n *node) DOTID() string {
+	return fmt.Sprintf("Node_%p", n.n)
+}
+
+// Attributes is for graphviz output. It specifies the "label" of the node (a table)
+func (n *node) Attributes() []encoding.Attribute {
+	var htmlEscaper = strings.NewReplacer(
+		`&`, "&amp;",
+		`'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+		`<`, "&lt;",
+		`>`, "&gt;",
+		`{`, "\\n",
+		`}`, "\\n",
+		`"`, "&#34;", // "&#34;" is shorter than "&quot;".
+		`const`, "const|", // "&#34;" is shorter than "&quot;".
+	)
+	attrs := []encoding.Attribute{
+		encoding.Attribute{
+			Key:   "id",
+			Value: fmt.Sprintf(`"%p"`, n.n),
+		},
+		encoding.Attribute{
+			Key:   "shape",
+			Value: "Mrecord",
+		},
+		encoding.Attribute{
+			Key:   "label",
+			Value: fmt.Sprintf(`"{{%s|%#x}|{Op|%s}|{Shape|%v}}"`, n.n.Name(), n.ID(), htmlEscaper.Replace(fmt.Sprintf("%s", n.n.Op())), n.n.Shape()),
+		},
+	}
+	return attrs
+}

--- a/encoding/dot/topgraph.go
+++ b/encoding/dot/topgraph.go
@@ -1,0 +1,62 @@
+package dot
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+	gonumDot "gonum.org/v1/gonum/graph/encoding/dot"
+	"gonum.org/v1/gonum/graph/simple"
+	"gorgonia.org/gorgonia"
+	gencoding "gorgonia.org/gorgonia/encoding"
+)
+
+var (
+	subGraphs = map[gencoding.GroupID]subgrapher{
+		gencoding.ConstantCluster: constantSubGraph{
+			DirectedBuilder: simple.NewDirectedGraph(),
+			name:            "Constants",
+		},
+		gencoding.InputCluster: inputSubGraph{
+			DirectedBuilder: simple.NewDirectedGraph(),
+			name:            "Inputs",
+		},
+		gencoding.ExprGraphCluster: exprSubGraph{
+			DirectedBuilder: simple.NewDirectedGraph(),
+			name:            "ExprGraph",
+		},
+		gencoding.UndefinedCluster: exprSubGraph{
+			DirectedBuilder: simple.NewDirectedGraph(),
+			name:            "ExprGraph",
+		},
+	}
+)
+
+type attributer []encoding.Attribute
+
+func (a attributer) Attributes() []encoding.Attribute { return a }
+
+func generateDotGraph(g *gorgonia.ExprGraph) (graph.Graph, error) {
+	dg := simple.NewDirectedGraph()
+	copyGraph(dg, g)
+	nodes := dg.Nodes()
+
+	for nodes.Next() {
+		n := nodes.Node()
+		if _, ok := n.(gencoding.Grouper); ok {
+			group := n.(gencoding.Grouper).Group()
+			if subgrapher, ok := subGraphs[group]; ok {
+				n := &node{
+					n: n.(*gorgonia.Node),
+				}
+				subgrapher.(graph.DirectedBuilder).AddNode(n)
+			}
+		}
+	}
+	subs := make([]gonumDot.Graph, 0, len(subGraphs))
+	for _, g := range subGraphs {
+		subs = append(subs, g)
+	}
+	return dotGraph{
+		Directed: dg,
+		subs:     subs,
+	}, nil
+}

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -1,0 +1,9 @@
+package encoding
+
+// GroupID represent a cluster of elements
+type GroupID int
+
+// Grouper is any object that can claim itself as being part of a group
+type Grouper interface {
+	Group() GroupID
+}


### PR DESCRIPTION
This PR holds some code I made a while ago.
The ultimate goal is to remove the `ToDot` from the main package.
Using an external package gives the ability to easily adapt the dot output without breaking any code mainstream.

I may add a notion of `groups` within the node; This is useful for writing the dot output, but may also be useful for encoding into `onnx` (an operator can be composed of a group of node, and we need to identify it to encode properly)