### PR TITLE
Fix when noasm tag is used

### DIFF
--- a/mathutils_go.go
+++ b/mathutils_go.go
@@ -1,4 +1,4 @@
-// +build wasm
+// +build noasm wasm
 
 package gorgonia
 


### PR DESCRIPTION
Compilation fails when noasm is used, as this method is not defined in that case.
This is a fix for #311 