### PR TITLE
Fix stabilization for Log(x+k), k!=1

### DIFF
--- a/stabilization.go
+++ b/stabilization.go
@@ -43,8 +43,11 @@ func logStabilization(a *Node) (retVal *Node, err error) {
 		if cnst, ok := input1.op.(constant); ok {
 			if constEq(cnst, onef32ConstOp) || constEq(cnst, onef64ConstOp) {
 				x = input0
+				break
 			}
 		}
+
+		return a, noStabilizationErr{}
 	case subOpType:
 		if cnst, ok := input0.op.(constant); !ok || (ok && !constEq(cnst, onef32ConstOp) && !constEq(cnst, onef64ConstOp)) {
 			return a, noStabilizationErr{}

--- a/stabilization_test.go
+++ b/stabilization_test.go
@@ -51,6 +51,15 @@ func TestLogStabilization(t *testing.T) {
 	if lp.children[0] == x {
 		t.Error("Oops.")
 	}
+
+	// log(a+2)
+	// We expect to keep the same operation tree, without stabilization
+	p = Must(Add(x, twof64))
+	lp = Must(Log(p))
+	if lp.children[0] != p {
+		t.Error("Oops.")
+		ioutil.WriteFile("log(a+2).dot", []byte(lp.ToDot()), 0644)
+	}
 }
 
 func TestExpStabilization(t *testing.T) {


### PR DESCRIPTION
This is a fix for the following issue:
When there is an operation like Log(x+2), the stabilization will replace it by Log(nil)
See unit test for an example.
Thanks!