### PR TITLE
Fix reduction bugs

### DIFF
--- a/op_reduction_test.go
+++ b/op_reduction_test.go
@@ -29,7 +29,30 @@ func TestSumOpGrad(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(1, len(grads))
 	t.Logf("%v", grads[0])
+}
 
+func TestSumOpFakeVec(t *testing.T) {
+	g := NewGraph()
+
+	xv := tensor.New(tensor.WithBacking([]float64{1, 2}), tensor.WithShape(2, 1))
+	yv := tensor.New(tensor.WithBacking([]float64{10, 20}), tensor.WithShape(1, 2))
+	x := NewMatrix(g, Float64, WithName("x"), WithShape(2, 1), WithValue(xv))
+	y := NewMatrix(g, Float64, WithName("y"), WithShape(1, 2), WithValue(yv))
+	sx, _ := Sum(x)
+	sy, _ := Sum(y)
+
+	assert.True(t, sx.Shape().Eq(tensor.ScalarShape()))
+	assert.True(t, sy.Shape().Eq(tensor.ScalarShape()))
+
+	sx2, _ := Sum(x, 1)
+	assert.True(t, sx2.Shape().Eq(tensor.Shape{2}))
+
+	vm := NewTapeMachine(g)
+	vm.RunAll()
+
+	assert.Equal(t, 3.0, sx.Value().Data(), "Expected sx to be 3.0")
+	assert.Equal(t, 30.0, sy.Value().Data(), "Expected sy to be 30.0")
+	assert.Equal(t, []float64{1, 2}, sx2.Value().Data(), "sx2 should be a flat array")
 }
 
 func TestSumOpDiff(t *testing.T) {

--- a/operations.go
+++ b/operations.go
@@ -327,8 +327,10 @@ func Sum(a *Node, along ...int) (retVal *Node, err error) {
 		switch {
 		case a.IsRowVec():
 			along = []int{1}
+			dims = 1
 		case a.IsColVec(), a.IsVector():
 			along = []int{0}
+			dims = 1
 		default:
 			along = intRange(0, dims)
 		}

--- a/shape_test.go
+++ b/shape_test.go
@@ -7,7 +7,7 @@ import (
 	"gorgonia.org/tensor"
 )
 
-func Example_KeepDims() {
+func Example_keepDims() {
 	g := NewGraph()
 	a := NodeFromAny(g, tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]float64{1, 2, 3, 4, 5, 6})))
 	m1, _ := Mean(a, 1)


### PR DESCRIPTION
Fixes reduction bugs while cleaning up some of the code.

* `len(shape)` is to be  discouraged, as future versions of `tensor.Shape` may be more static for performance reasons.
* `reductionInerSahpe` does not require `...DimSizer` as inputs. Instead, now checks are made so that they only take `tensor.Shape`.

The bug being resolved can be described as follows: 

```
func TestSumOpFakeVec(t *testing.T) {
	g := NewGraph()

	xv := tensor.New(tensor.WithBacking([]float64{1, 2}), tensor.WithShape(2, 1))
	yv := tensor.New(tensor.WithBacking([]float64{10, 20}), tensor.WithShape(1, 2))
	x := NewMatrix(g, Float64, WithName("x"), WithShape(2, 1), WithValue(xv))
	y := NewMatrix(g, Float64, WithName("y"), WithShape(1, 2), WithValue(yv))
	sx, _ := Sum(x)
	sy, _ := Sum(y)

	assert.True(t, sx.Shape().Eq(tensor.ScalarShape()))
	assert.True(t, sy.Shape().Eq(tensor.ScalarShape()))

	sx2, _ := Sum(x, 1)
	assert.True(t, sx2.Shape().Eq(tensor.Shape{2}))

	vm := NewTapeMachine(g)
	vm.RunAll()

	assert.Equal(t, 3.0, sx.Value().Data(), "Expected sx to be 3.0")
	assert.Equal(t, 30.0, sy.Value().Data(), "Expected sy to be 30.0")
	assert.Equal(t, []float64{1, 2}, sx2.Value().Data(), "sx2 should be a flat array")
}
```

This test has also been added 

The cause of the bug is that `reductionInferShape` and `reductionType` do not agree with each other. 

This is due to an incompletely defined type system which hopefully will be fixed in the upcoming version. 

The current solution is a hack: we treat colvec and rowvec matrices as vectors in type inference. 