### PR TITLE
Fixes #363

### DIFF
--- a/operatorPointwise_unary.go
+++ b/operatorPointwise_unary.go
@@ -311,10 +311,21 @@ func negDiff(x, y *Node) (err error) {
 	xdv, ydv := getDV(x, y)
 
 	sub := newElemBinOp(subOpType, x, y)
-	_, err = sub.UnsafeDo(xdv.d, ydv.d)
+	var d Value
+	d, err = sub.UnsafeDo(xdv.d, ydv.d)
+
+	// first we check if what essentially is a noIncrError is called
 	if err = checkErrSetDeriv(err, xdv); err != nil {
 		return errors.Wrapf(err, autodiffFail, x)
 	}
+
+	// then we set derivs, if d is a scalar
+	if _, ok := xdv.Value.(Scalar); ok {
+		if err = xdv.SetDeriv(d); err != nil {
+			return errors.Wrapf(err, autodiffFail, x)
+		}
+	}
+
 	return
 }
 


### PR DESCRIPTION
The main problem was in the diff function of `Neg`. It should increment the derivative of x, but a wrong method was called (`UnsafeDo`).
This makes it fail for values that are scalars. This has been fixed.