### PR TITLE
Fixed #368 - the cause is an off-by-one bug in the SoftMax function. A

### DIFF
--- a/known_issues_test.go
+++ b/known_issues_test.go
@@ -1,6 +1,7 @@
 package gorgonia
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -299,4 +300,14 @@ func TestIssue363(t *testing.T) {
 
 	t.Log("xgrad=", actualxgrad, "ygrad=", actualygrad)
 
+}
+
+func TestIssue368(t *testing.T) {
+	g := NewGraph()
+	x := NewTensor(g, Float32, 2, WithShape(2, 5), WithInit(GlorotU(1.0)))
+	sm, err := SoftMax(x, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = sm
 }

--- a/operations.go
+++ b/operations.go
@@ -166,7 +166,7 @@ func SoftMax(a *Node, axes ...int) (retVal *Node, err error) {
 	}
 
 	if len(axes) > 0 {
-		if axes[0] >= axis || axes[0] < 0 {
+		if axes[0] >= axis+1 || axes[0] < 0 {
 			return nil, errors.Errorf("Cannot perform SoftMax on axis %d. Input has shape %v", axes[0], a.Shape())
 		}
 		axis = axes[0]


### PR DESCRIPTION
comparison was made against the (n-1)th rank of a tensor, rather than
the nth rank of the tensor.