### PR TITLE
fix return value as pointer in scalar bin ops

### DIFF
--- a/operatorPointwise_binary.go
+++ b/operatorPointwise_binary.go
@@ -119,9 +119,9 @@ func (o scalarBinOp) Do(same bool, vals ...Value) (retVal Value, err error) {
 
 		if same && !o.isArith() {
 			if *(r.(*B)) {
-				r = F32(1)
+				r = newF32(1)
 			} else {
-				r = F32(0)
+				r = newF32(0)
 			}
 		}
 
@@ -156,9 +156,9 @@ func (o scalarBinOp) Do(same bool, vals ...Value) (retVal Value, err error) {
 
 		if same && !o.isArith() {
 			if *(r.(*B)) {
-				r = I(1)
+				r = newI(1)
 			} else {
-				r = I(0)
+				r = newI(0)
 			}
 		}
 	case *I32:
@@ -192,9 +192,9 @@ func (o scalarBinOp) Do(same bool, vals ...Value) (retVal Value, err error) {
 
 		if same && !o.isArith() {
 			if *(r.(*B)) {
-				r = I32(1)
+				r = newI32(1)
 			} else {
-				r = I32(0)
+				r = newI32(0)
 			}
 		}
 	case *I64:
@@ -228,9 +228,9 @@ func (o scalarBinOp) Do(same bool, vals ...Value) (retVal Value, err error) {
 
 		if same && !o.isArith() {
 			if *(r.(*B)) {
-				r = I64(1)
+				r = newI64(1)
 			} else {
-				r = I64(0)
+				r = newI64(0)
 			}
 		}
 	case *U8:
@@ -264,9 +264,9 @@ func (o scalarBinOp) Do(same bool, vals ...Value) (retVal Value, err error) {
 
 		if same && !o.isArith() {
 			if *(r.(*B)) {
-				r = U8(1)
+				r = newU8(1)
 			} else {
-				r = U8(0)
+				r = newU8(0)
 			}
 		}
 	case *B:

--- a/operatorPointwise_binary_test.go
+++ b/operatorPointwise_binary_test.go
@@ -33,6 +33,7 @@ func ssBinOpTest(t *testing.T, op ʘBinaryOperatorType, dt tensor.Dtype) (err er
 	var g, g2 *ExprGraph
 	var x, y, z *Node
 	var a, b, c *Node
+	var i, j, k *Node
 	g = NewGraph()
 	x = NewScalar(g, dt, WithName("x"))
 	y = NewScalar(g, dt, WithName("y"))
@@ -44,6 +45,13 @@ func ssBinOpTest(t *testing.T, op ʘBinaryOperatorType, dt tensor.Dtype) (err er
 	a = NewScalar(g2, dt, WithName("a"))
 	b = NewScalar(g2, dt, WithName("b"))
 	if c, err = ApplyOp(binOp, a, b); err != nil {
+		return err
+	}
+
+	i = NewScalar(g, dt, WithName("i"))
+	j = NewScalar(g, dt, WithName("j"))
+	binOp.retSame = true
+	if k, err = ApplyOp(binOp, i, j); err != nil {
 		return err
 	}
 
@@ -64,6 +72,8 @@ func ssBinOpTest(t *testing.T, op ʘBinaryOperatorType, dt tensor.Dtype) (err er
 
 	Let(x, randX)
 	Let(y, randY)
+	Let(i, randX)
+	Let(j, randY)
 	if err = m1.RunAll(); err != nil {
 		return
 	}
@@ -93,6 +103,17 @@ func ssBinOpTest(t *testing.T, op ʘBinaryOperatorType, dt tensor.Dtype) (err er
 			return
 		}
 		if cG, err = c.Grad(); err != nil {
+			return
+		}
+
+		if _, err = i.Grad(); err != nil {
+			return
+		}
+
+		if _, err = j.Grad(); err != nil {
+			return
+		}
+		if _, err = k.Grad(); err != nil {
 			return
 		}
 


### PR DESCRIPTION
Scalar bin ops requires creating a pointer to a scalar when returning the same value type.