### PR TITLE
Fix Max() op + tests

### DIFF
--- a/op_reduction.go
+++ b/op_reduction.go
@@ -152,7 +152,7 @@ func (op maxOp) SymDiff(inputs Nodes, output, gradNode *Node) (retVal Nodes, err
 	if a, b, err = Broadcast(output, t, bcpat); err != nil {
 		return nil, errors.Wrap(err, operationError)
 	}
-	if eq, err = Eq(a, b, false); err != nil {
+	if eq, err = Eq(a, b, true); err != nil {
 		return nil, errors.Wrap(err, operationError)
 	}
 
@@ -160,7 +160,7 @@ func (op maxOp) SymDiff(inputs Nodes, output, gradNode *Node) (retVal Nodes, err
 		return nil, errors.Wrap(err, operationError)
 	}
 	retVal = make(Nodes, 1)
-	if retVal[0], err = Mul(a2, b2); err != nil {
+	if retVal[0], err = HadamardProd(a2, b2); err != nil {
 		return nil, errors.Wrap(err, operationError)
 	}
 	return

--- a/op_reduction_test.go
+++ b/op_reduction_test.go
@@ -229,6 +229,7 @@ func TestMaxOp(t *testing.T) {
 		{dt: Float32, inShape: []int{3, 2}, inData: []float32{1, 2, 3, 4, 5, 6}, op: Max, along: []int{}, wantShape: []int{}, wantData: float32(6)},
 		{dt: Float32, inShape: []int{3, 2}, inData: []float32{1, 2, 3, 4, 5, 6}, op: Max, along: []int{0, 1}, wantShape: []int{}, wantData: float32(6)},
 		{dt: Float32, inShape: []int{3, 2}, inData: []float32{1, 2, 3, 4, 5, 6}, op: Max, along: []int{1, 0}, wantShape: []int{}, wantData: float32(6)},
+		//{dt: Float32, inShape: []int{1, 6}, inData: []float32{1, 2, 3, 4, 5, 6}, op: Max, along: []int{1}, wantShape: []int{}, wantData: float32(6)},
 		{
 			dt:        Float32,
 			inShape:   []int{2, 2, 2, 2},
@@ -424,6 +425,133 @@ func testReductionOp(t *testing.T, test reductionTest) {
 	assert := assert.New(t)
 	assert.Equal(test.wantShape, got.Value().Shape(), "shape mismatch")
 	assert.Equal(test.wantData, got.Value().Data(), "data mismatch")
+}
+
+func TestMaxOpGrad(t *testing.T) {
+	subTests := []reductionGradTest{
+		{
+			dt:           Float64,
+			inShape:      tensor.Shape{6},
+			inData:       []float64{1, 2, 3, 4, 5, 6},
+			op:           Max,
+			along:        []int{},
+			outGradShape: tensor.Shape{1},
+			outGrad:      []float64{1},
+			wantInGrad:   []float64{0, 0, 0, 0, 0, 1},
+		},
+		{
+			dt:           Float32,
+			inShape:      tensor.Shape{6},
+			inData:       []float32{1, 2, 3, 4, 5, 6},
+			op:           Max,
+			along:        []int{0},
+			outGradShape: tensor.Shape{1},
+			outGrad:      []float32{1},
+			wantInGrad:   []float32{0, 0, 0, 0, 0, 1},
+		},
+		{
+			dt:           Float32,
+			inShape:      tensor.Shape{6},
+			inData:       []float32{1, 2, 3, 4, 5, 6},
+			op:           Max,
+			along:        []int{},
+			outGradShape: tensor.Shape{1},
+			outGrad:      []float32{1},
+			wantInGrad:   []float32{0, 0, 0, 0, 0, 1},
+		},
+		{
+			dt:           Float32,
+			inShape:      tensor.Shape{3, 2},
+			inData:       []float32{1, 2, 3, 4, 5, 6},
+			op:           Max,
+			along:        []int{0},
+			outGradShape: tensor.Shape{2},
+			outGrad:      []float32{0.2, 0.8},
+			wantInGrad:   []float32{0, 0, 0, 0, 0.2, 0.8},
+		},
+		{
+			dt:           Float32,
+			inShape:      tensor.Shape{3, 2},
+			inData:       []float32{1, 2, 3, 4, 5, 6},
+			op:           Max,
+			along:        []int{1},
+			outGradShape: tensor.Shape{3},
+			outGrad:      []float32{0.1, 0.3, 0.6},
+			wantInGrad:   []float32{0, 0.1, 0, 0.3, 0, 0.6},
+		},
+		{
+			dt:           Float32,
+			inShape:      tensor.Shape{3, 2},
+			inData:       []float32{1, 2, 3, 4, 5, 6},
+			op:           Max,
+			along:        []int{0, 1},
+			outGradShape: tensor.Shape{1},
+			outGrad:      []float32{1},
+			wantInGrad:   []float32{0, 0, 0, 0, 0, 1},
+		},
+		//{
+		//	dt:           Float32,
+		//	inShape:      tensor.Shape{1, 6},
+		//	inData:       []float32{1, 2, 3, 4, 5, 6},
+		//	op:           Max,
+		//	along:        []int{1},
+		//	outGradShape: tensor.Shape{6},
+		//	outGrad:      []float32{1},
+		//	wantInGrad:   []float32{0, 0, 0, 0, 0, 1},
+		//},
+	}
+
+	for _, subTest := range subTests {
+		t.Run(fmt.Sprintf("%v along %v %v", subTest.inShape, subTest.along, subTest.dt), func(t *testing.T) {
+			testReductionOpGrad(t, subTest)
+		})
+	}
+}
+
+type reductionGradTest struct {
+	dt           tensor.Dtype
+	inShape      tensor.Shape
+	inData       interface{}
+	op           func(*Node, ...int) (*Node, error)
+	along        []int
+	outGradShape tensor.Shape
+	outGrad      interface{}
+	wantInGrad   interface{}
+}
+
+func testReductionOpGrad(t *testing.T, test reductionGradTest) {
+	assert := assert.New(t)
+
+	var xG Value
+	var err error
+
+	// Run op
+	g := NewGraph()
+	xN := NewTensor(g, test.dt, len(test.inShape), WithShape(test.inShape...))
+	y := Must(test.op(xN, test.along...))
+
+	outGrad := NewTensor(g, test.dt, len(test.outGradShape), WithValue(tensor.New(tensor.WithShape(test.outGradShape...), tensor.WithBacking(test.outGrad))))
+	if _, err = Backpropagate(Nodes{y}, Nodes{outGrad}, Nodes{xN}); err != nil {
+		t.Fatal(err)
+	}
+
+	xT := tensor.New(tensor.WithShape(test.inShape...), tensor.WithBacking(test.inData))
+	vm := NewTapeMachine(g)
+	defer vm.Close()
+	vm.Let(xN, xT)
+	if err = vm.RunAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test grad functions
+	diffWRT := y.diffWRT()
+	assert.Equal([]bool{true}, diffWRT)
+
+	if xG, err = xN.Grad(); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(test.inShape, xG.Shape(), "grad shape mismatch")
+	assert.Equal(test.wantInGrad, xG.Data(), "grad data mismatch")
 }
 
 // TestFollowupOp confirms that an element-wise binary op will work as expected after a sum/max.


### PR DESCRIPTION
Partial fix for #323.

This should fix differentiation of the `Max()` op. Until now I had almost no experience with this so please check that the grads I'm asserting are what is supposed to happen. It does seem to work with a model I'm training.

I added 2 commented out tests. These do not work yet but should once #373 is fixed.

If you want I can create the same tests for the `Sum()` op. Let me know if you want that in a separate PR or added to this one.