### PR TITLE
Make cudagen work with Go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ _testmain.go
 *.test
 *.prof
 
+cudamodules.go
+
 # vendor
 /vendor

--- a/cuda.go
+++ b/cuda.go
@@ -33,10 +33,15 @@ const (
 	scalarAlign = 8
 )
 
-var cudaStdLib map[string]string
-var cudaStdFuncs map[string][]string
-
 //go:generate cudagen
+
+var cudaStdLib []cudaLib
+
+type cudaLib struct {
+	name  string
+	data  string
+	funcs []string
+}
 
 // CUDAMachine is a representation of CUDA capable VMs.
 type CUDAMachine interface {
@@ -293,8 +298,12 @@ func (m *ExternMetadata) setEngine(e tensor.Engine) {}
 
 // AddToStdLib allows for custom ops to be included into the "stdlib" of CUDA functions, so that when the VMs are created, they're loaded automatically
 // without having to specify extra loading.
-func AddToStdLib(name, data string) {
-	cudaStdLib[name] = data
+func AddToStdLib(name, data string, funcs []string) {
+	cudaStdLib = append(cudaStdLib, cudaLib{
+		name:  name,
+		data:  data,
+		funcs: funcs,
+	})
 }
 
 func init() {

--- a/cuda.go
+++ b/cuda.go
@@ -33,7 +33,7 @@ const (
 	scalarAlign = 8
 )
 
-//go:generate cudagen
+//go:generate cudagen -same-module
 
 var cudaStdLib []cudaLib
 

--- a/cuda/builtin.go
+++ b/cuda/builtin.go
@@ -2,9 +2,6 @@ package cuda
 
 //go:generate cudagen
 
-var cudaStdLib map[string]string
-var cudaStdFuncs map[string][]string
-
 const (
 	elemBinOpMod   = "elembinop"
 	elemUnaryOpMod = "elemunaryop"

--- a/cuda_test.go
+++ b/cuda_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDevCUDA(t *testing.T) {
-	 t.SkipNow()
+	t.SkipNow()
 
 	g := NewGraph()
 	x := NewMatrix(g, Float64, WithShape(1024, 100), WithName("x"), WithInit(ValuesOf(2.0)))
@@ -55,7 +55,6 @@ func TestDevCUDA(t *testing.T) {
 	if assertGraphEngine(t, g, stdengType); t.Failed() {
 		t.FailNow()
 	}
-
 }
 
 func TestExternMetadata_Transfer(t *testing.T) {

--- a/vm_genera_cuda.go
+++ b/vm_genera_cuda.go
@@ -164,19 +164,12 @@ func (m *lispMachine) loadStdLib() {
 		return
 	}
 
-	for name, data := range cudaStdLib {
-		funcs, ok := cudaStdFuncs[name]
-		if !ok {
-			cudaLogf("No funcs for module %q", name)
-			// panic("WTF")
-			continue
-		}
+	for _, lib := range cudaStdLib {
 		for i := range m.engines {
 			e := &m.engines[i]
-			if err := e.LoadCUDAFunc(name, data, funcs); err != nil {
+			if err := e.LoadCUDAFunc(lib.name, lib.data, lib.funcs); err != nil {
 				panic(err)
 			}
-
 		}
 	}
 }

--- a/vm_tape_cuda.go
+++ b/vm_tape_cuda.go
@@ -46,16 +46,10 @@ func (m *tapeMachine) loadStdLib() {
 		return
 	}
 
-	for name, data := range cudaStdLib {
-		funcs, ok := cudaStdFuncs[name]
-		if !ok {
-			cudaLogf("No funcs for module %q", name)
-			// panic("WTF")
-			continue
-		}
+	for _, lib := range cudaStdLib {
 		for i := range m.engines {
 			e := &m.engines[i]
-			if err := e.LoadCUDAFunc(name, data, funcs); err != nil {
+			if err := e.LoadCUDAFunc(lib.name, lib.data, lib.funcs); err != nil {
 				panic(err)
 			}
 		}


### PR DESCRIPTION
Closes #380.

- Compilation output is now placed in the system's temp directory and removed afterwards.
- `cudamodules.go` will be placed in the current directory.
- I changed the signature of `AddToStdLib`. It now accepts a list of functions. I assume this function is only used by `cudamodules.go` but because it's an exported function it still breaks the interface.
- Added a flag `-same-module` for when you need to create a `cudamodules.go` file in the gorgonia package (for when you want to run tests with cuda). Updated the `go:generate` directive in the gorgonia package so it will use this flag.
- Removed the commented out nvcc command with the "fast" flags. If you need this I can put it back but behind a flag or something?
- I'm kind of able to run a my own model with this. However, before I started I got a lot of problems with failing tests and the convnet_cuda example ([this](https://github.com/gorgonia/gorgonia/issues/376#issuecomment-586973675) and some other things) and that is still the case. So I'm unable to test everything.
- Tested with Go modules. Not tested _without_ Go modules but I confirmed that the go commands that are used to get the gorgonia package path and current package name do work with Go 11.

Output looks like:
```golang
// Code generated by Gorgonia cudagen. DO NOT EDIT.
// +build cuda

package gorgonia_speech_commands

import "gorgonia.org/gorgonia"

func init() {
	gorgonia.AddToStdLib("elembinop", elembinopPTX, []string{"add_vv_f64", "add_vv_f32", "sub_vv_f64", "sub_vv_f32", "mul_vv_f64", "mul_vv_f32", "div_vv_f64", "div_vv_f32", "gt_vv_f64", "gt_vv_f32", "gte_vv_f64", "gte_vv_f32", "lt_vv_f64", "lt_vv_f32", "lte_vv_f64", "lte_vv_f32", "eq_vv_f64", "eq_vv_f32", "ne_vv_f64", "ne_vv_f32", "add_vs_f64", "add_vs_f32", "sub_vs_f64", "sub_vs_f32", "mul_vs_f64", "mul_vs_f32", "div_vs_f64", "div_vs_f32", "gt_vs_f64", "gt_vs_f32", "gte_vs_f64", "gte_vs_f32", "lt_vs_f64", "lt_vs_f32", "lte_vs_f64", "lte_vs_f32", "eq_vs_f64", "eq_vs_f32", "ne_vs_f64", "ne_vs_f32", "add_sv_f64", "add_sv_f32", "sub_sv_f64", "sub_sv_f32", "mul_sv_f64", "mul_sv_f32", "div_sv_f64", "div_sv_f32", "gt_sv_f64", "gt_sv_f32", "gte_sv_f64", "gte_sv_f32", "lt_sv_f64", "lt_sv_f32", "lte_sv_f64", "lte_sv_f32", "eq_sv_f64", "eq_sv_f32", "ne_sv_f64", "ne_sv_f32", "add_ss_f64", "add_ss_f32", "sub_ss_f64", "sub_ss_f32", "mul_ss_f64", "mul_ss_f32", "div_ss_f64", "div_ss_f32", "gt_ss_f64", "gt_ss_f32", "gte_ss_f64", "gte_ss_f32", "lt_ss_f64", "lt_ss_f32", "lte_ss_f64", "lte_ss_f32", "eq_ss_f64", "eq_ss_f32", "ne_ss_f64", "ne_ss_f32", "pow_vv_f64", "pow_vv_f32", "pow_vs_f64", "pow_vs_f32", "pow_sv_f64", "pow_sv_f32", "pow_ss_f64", "pow_ss_f32"})
	gorgonia.AddToStdLib("elemunaryop", elemunaryopPTX, []string{"cos_f64", "sin_f64", "exp_f64", "ln_f64", "log2_f64", "sqrt_f64", "tanh_f64", "log1p_f64", "expm1_f64", "abs_f64", "ceil_f64", "floor_f64", "sign_f64", "square_f64", "cube_f64", "neg_f64", "inverse_f64", "softplus_f64", "sigmoid_f64", "cos_f32", "sin_f32", "exp_f32", "ln_f32", "log2_f32", "sqrt_f32", "tanh_f32", "log1p_f32", "expm1_f32", "abs_f32", "ceil_f32", "floor_f32", "sign_f32", "square_f32", "cube_f32", "neg_f32", "inverse_f32", "softplus_f32", "sigmoid_f32"})
	gorgonia.AddToStdLib("misc", miscPTX, []string{"hasNaN_f32", "hasNaN_f64", "hasInf_f32", "hasInf_f64"})
	gorgonia.AddToStdLib("sigmoid32", sigmoid32PTX, []string{"sigmoid32"})
	gorgonia.AddToStdLib("sigmoid64", sigmoid64PTX, []string{"sigmoid64"})
}

const sigmoid32PTX = `//
// ...
`
```