### PR TITLE
Fix convnet example

### DIFF
--- a/examples/convnet/main.go
+++ b/examples/convnet/main.go
@@ -216,8 +216,8 @@ func main() {
 		log.Fatalf("%+v", err)
 	}
 	losses := gorgonia.Must(gorgonia.Log(gorgonia.Must(gorgonia.HadamardProd(m.out, y))))
-	cost := gorgonia.Must(gorgonia.Neg(cost))
-	cost = gorgonia.Must(gorgonia.Mean(losses))
+	cost := gorgonia.Must(gorgonia.Mean(losses))
+	cost = gorgonia.Must(gorgonia.Neg(cost))
 
 	// we wanna track costs
 	var costVal gorgonia.Value


### PR DESCRIPTION
convnet example seems to be broken.

```
$ go build -o convnet ./examples/convnet/
# gorgonia.org/gorgonia/examples/convnet
examples/convnet/main.go:219:37: undefined: cost
```

https://github.com/gorgonia/gorgonia/blob/cb4f110a9c3a9bbc51339bf8042b039169160ed3/examples/convnet/main.go#L219-L220

So I fix this error. The source code at v0.9.0-beta is following:

https://github.com/gorgonia/gorgonia/blob/978b1c3c0f795d09d0710238cb5f82853b99a460/examples/convnet/main.go#L219-L220

