### PR TITLE
Fix mnist loader

### DIFF
--- a/examples/mnist/mnist.go
+++ b/examples/mnist/mnist.go
@@ -23,10 +23,10 @@ type Label uint8
 // loc represents where the mnist files are held
 func Load(typ, loc string, as tensor.Dtype) (inputs, targets tensor.Tensor, err error) {
 	const (
-		trainLabel = "train-labels.idx1-ubyte"
-		trainData  = "train-images.idx3-ubyte"
-		testLabel  = "t10k-labels.idx1-ubyte"
-		testData   = "t10k-images.idx3-ubyte"
+		trainLabel = "train-labels-idx1-ubyte"
+		trainData  = "train-images-idx3-ubyte"
+		testLabel  = "t10k-labels-idx1-ubyte"
+		testData   = "t10k-images-idx3-ubyte"
 	)
 
 	var labelFile, dataFile string


### PR DESCRIPTION
I download mnist data by [`examples/mnist/download.sh`](https://github.com/gorgonia/gorgonia/blob/master/examples/mnist/download.sh), then execute `convnet` example. But  I got following errors:

```
$ ./bin/gorgonia_convnet
2020/04/19 22:10:35 Unable to read Labels: open /Users/a14737/go/src/github.com/c-bata/goptuna/_examples/gorgonia_convnet/data/train-labels.idx1-ubyte: no such file or directory
```

The reason why I got this error is just missed file name. `download.sh` generated a file train-labels-idx1-ubyte, not train-labels.idx1-ubyte. I fix this problem on this pull request.