### PR TITLE
Add failing tests for concat/unconcat ops

### DIFF
--- a/op_tensor_test.go
+++ b/op_tensor_test.go
@@ -1,6 +1,7 @@
 package gorgonia
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -297,51 +298,164 @@ func TestTransposeOp(t *testing.T) {
 	assert.True(ValueEq(ag, bg))
 }
 
+type concatOpTest struct {
+	name string
+	axes int
+	vals []Value
+
+	correct Value
+}
+
+var concatOpTests = []concatOpTest{
+	{
+		"concat 2 vectors",
+		0,
+		[]Value{
+			tensor.New(tensor.WithBacking([]float64{1, 2}), tensor.WithShape(2)),
+			tensor.New(tensor.WithBacking([]float64{3, 4}), tensor.WithShape(2)),
+		},
+		tensor.New(tensor.WithBacking([]float64{1, 2, 3, 4}), tensor.WithShape(4)),
+	},
+	{
+		"concat 2 matrices on dim with size of 1",
+		1,
+		[]Value{
+			tensor.New(tensor.WithBacking([]float64{1, 2}), tensor.WithShape(2, 1)),
+			tensor.New(tensor.WithBacking([]float64{3, 4}), tensor.WithShape(2, 1)),
+		},
+		tensor.New(tensor.WithBacking([]float64{1, 3, 2, 4}), tensor.WithShape(2, 2)),
+	},
+}
+
 func TestConcatOp(t *testing.T) {
+	for _, cot := range concatOpTests {
+		t.Run(cot.name, func(t *testing.T) {
+			testConcatOp(t, cot)
+		})
+	}
+}
+
+func testConcatOp(t *testing.T, cot concatOpTest) {
 	defer runtime.GC()
 
-	assert := assert.New(t)
-	g := NewGraph()
-	x := NewVector(g, Float64, WithShape(2))
-	xx, err := Concat(0, x, x)
+	as := assert.New(t)
+	g1 := NewGraph()
+	g2 := NewGraph()
+
+	var n1, n2 Nodes
+	for i, v := range cot.vals {
+		n1 = append(n1, NodeFromAny(g1, v, WithName(fmt.Sprintf("n1_%d", i))))
+		n2 = append(n2, NodeFromAny(g2, v, WithName(fmt.Sprintf("n2_%d", i))))
+	}
+
+	xx, err := Concat(cot.axes, n1...)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	aa, err := Concat(cot.axes, n2...)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 
-	cost := Must(Sum(xx))
-	Grad(cost, x)
-
-	g2 := NewGraph()
-	a := NewVector(g2, Float64, WithShape(2))
-	aa, err := Concat(0, a, a)
+	cost1 := Must(Sum(xx))
+	_, err = Grad(cost1, n1...)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 	Must(Sum(aa)) // cost
 
-	aBack := []float64{1, 2}
-	aT := tensor.New(tensor.WithShape(2), tensor.WithBacking(aBack))
-
-	xBack := []float64{1, 2}
-	xT := tensor.New(tensor.WithShape(2), tensor.WithBacking(xBack))
-
-	Let(a, aT)
-	Let(x, xT)
-	m1 := NewTapeMachine(g)
-	m2 := NewLispMachine(g2)
-	defer m1.Close()
-	defer m2.Close()
-
+	m1 := NewTapeMachine(g1)
 	if err = m1.RunAll(); err != nil {
 		t.Fatal(err)
 	}
-
+	defer m1.Close()
+	m2 := NewLispMachine(g2)
 	if err = m2.RunAll(); err != nil {
+		t.Fatal(err)
+	}
+	defer m2.Close()
+
+	xG, err := xx.Grad()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	aG, err := aa.Grad()
+	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 
-	xG, _ := x.Grad()
-	aG, _ := a.Grad()
-	assert.True(ValueEq(xG, aG))
-	assert.True(ValueEq(xx.Value(), aa.Value()))
+	as.True(ValueEq(cot.correct, xx.Value()))
+	as.True(ValueEq(xG, aG))
+
+	// Grads must have the same shapes as the input values
+	for i, v := range cot.vals {
+		g1, err := n1[i].Grad()
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		as.Equal(v.Shape(), g1.Shape())
+
+		g2, err := n1[i].Grad()
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		as.Equal(v.Shape(), g2.Shape())
+	}
+}
+
+func TestUnconcatConcatOpSequence(t *testing.T) {
+	defer runtime.GC()
+
+	as := assert.New(t)
+	g := NewGraph()
+
+	x := NewTensor(g, tensor.Float64, 3, WithShape(2, 3, 3), WithName("x"), WithValue(tensor.New(tensor.WithShape(2, 3, 3), tensor.WithBacking([]float64{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+
+		10, 11, 12,
+		13, 14, 15,
+		16, 17, 18,
+	}))))
+
+	ux, err := Unconcat(x, 2, 3)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	as.Len(ux, 3)
+
+	for i, n := range ux {
+		ux[i], err = Reshape(n, tensor.Shape{2, 3, 1})
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+	}
+
+	cx, err := Concat(2, ux...)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	cost := Must(Sum(cx))
+	_, err = Grad(cost, x)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	m := NewTapeMachine(g)
+	if err = m.RunAll(); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	defer m.Close()
+
+	xG, err := x.Grad()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	as.True(ValueEq(x.Value(), cx.Value()))
+	as.Equal([]float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, xG.Data())
+	as.True(tensor.Shape{2, 3, 3}.Eq(xG.Shape()))
 }


### PR DESCRIPTION
Added some failing tests for something that I expected to work and I need to build a LSTM layer. One of the errors I get is:

```
=== RUN   TestUnconcatConcatOpSequence
--- FAIL: TestUnconcatConcatOpSequence (0.00s)
    op_tensor_test.go:449: "Reshape" not yet implemented for non-contiguous views
        gorgonia.org/tensor.(*Dense).Reshape
        	/home/markkremer/go/pkg/mod/gorgonia.org/tensor@v0.9.6/dense.go:146
        gorgonia.org/gorgonia.reshapeOp.UnsafeDo
        	..../Go/src/github.com/MarkKremer/gorgonia/op_tensor.go:1205
        gorgonia.org/gorgonia.(*execOp).exec
        	..../Go/src/github.com/MarkKremer/gorgonia/vm_tape_nocuda.go:52
        gorgonia.org/gorgonia.(*tapeMachine).runall
        	..../Go/src/github.com/MarkKremer/gorgonia/vm_tape.go:236
        runtime.goexit
        	/usr/local/go/src/runtime/asm_amd64.s:1357
        Failed to carry UnsafeDo()
        gorgonia.org/gorgonia.(*execOp).exec
        	..../Go/src/github.com/MarkKremer/gorgonia/vm_tape_nocuda.go:53
        gorgonia.org/gorgonia.(*tapeMachine).runall
        	..../Go/src/github.com/MarkKremer/gorgonia/vm_tape.go:236
        runtime.goexit
        	/usr/local/go/src/runtime/asm_amd64.s:1357
        PC 12. Failed to execute instruction Reshape(2, 3, 1)	[CPU3]	CPU3	false	true	false
        gorgonia.org/gorgonia.(*tapeMachine).runall
        	..../Go/src/github.com/MarkKremer/gorgonia/vm_tape.go:237
        runtime.goexit
        	/usr/local/go/src/runtime/asm_amd64.s:1357
        PC: 12
        gorgonia.org/gorgonia.(*tapeMachine).RunAll
        	..../Go/src/github.com/MarkKremer/gorgonia/vm_tape.go:220
        gorgonia.org/gorgonia.TestUnconcatConcatOpSequence
        	..../Go/src/github.com/MarkKremer/gorgonia/op_tensor_test.go:448
        testing.tRunner
        	/usr/local/go/src/testing/testing.go:909
        runtime.goexit
        	/usr/local/go/src/runtime/asm_amd64.s:1357
FAIL
```

What I noticed is:
- The concat op's SymDiff method doesn't always return a gradient of the same shape as the input nodes. This will cause problems when using that gradient in other ops.
- The compiler (compile.go -> codegenerator.addNode(...)) determines that the reshape can be done using the UnsafeDo method. But Unconcat returns a view which isn't supported by that method. I'm not entirely sure if we could just copy the `if v.IsView() { val = v.Materialize() }` code from the `Do()` method. Or should the compiler have a check instead that uses the safe `Do()` method if one or more of the inputs are views?

This is slightly related to #404 in that I need it for the same model and that something with the shapes is going wrong. But now that I have found the issues it doesn't have much overlap that is of interest for Gorgonia.