### PR TITLE
Make reductionInferShape conservative to fix #384

### DIFF
--- a/differentiation.go
+++ b/differentiation.go
@@ -31,7 +31,7 @@ func forwardDiffAnalysis(outputs, sortedNodes Nodes) (retVal NodeSet, err error)
 	// diffSet := outputs.Set()
 	diffSet := outputs.mapSet()
 
-	symdiffLogf("Diff Set: %d", diffSet)
+	symdiffLogf("Diff Set: %v", diffSet)
 	symdiffLogf("%d", sortedNodes)
 	// for i := len(sortedNodes) - 1; i ⩾ 0; i-- {
 	// 	n := sortedNodes[i]
@@ -216,7 +216,7 @@ func Backpropagate(outputs, gradOutputs, wrt Nodes) (retVal Nodes, err error) {
 	// "pullback" function to backpropagate derivatives
 	activeNodes := affectsOutput.Intersect(affectedByOutput)
 
-	symdiffLogf("Active: %d", activeNodes)
+	symdiffLogf("Active: %v", activeNodes)
 
 	symdiffLogf("Sorted: %d", sortedNodes)
 	symdiffLogf("nodeGradMap: %+#d", FmtNodeMap(nodeGradMap))

--- a/encoding/dot/issues_test.go
+++ b/encoding/dot/issues_test.go
@@ -1,0 +1,80 @@
+package dot
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorgonia.org/gorgonia"
+)
+
+// unmangleName replaces the pointer-based name with the node name.
+//
+// Node names are unique in Gorgonia graphs.
+// However we cannot use node names in a `.dot` file because there are some names
+// that will not be accepted by graphviz.
+//
+// Hence we use pointers as part of the name of the nodes. A node will have a name
+// like "Node_0xbadb100d" (shout out to Tay Tay!) in the `.dot` file.
+//
+// unmangleName replaces `Node_0xbadc0ffee` with the name of the node for the purposes of testing.
+func unmangleName(marshalled string, node *gorgonia.Node) string {
+	name := node.Name()
+	ptrName := fmt.Sprintf("%p", node)
+
+	return strings.Replace(marshalled, ptrName, name, -1)
+}
+
+func TestIssue_407(t *testing.T) {
+	// originally written by @wzzhu
+
+	assert := assert.New(t)
+	g := gorgonia.NewGraph()
+	var x, y, z *gorgonia.Node
+	var err error
+
+	// define the expression
+	x = gorgonia.NewScalar(g, gorgonia.Float64, gorgonia.WithName("x"))
+	y = gorgonia.NewScalar(g, gorgonia.Float64, gorgonia.WithName("y"))
+	if z, err = gorgonia.Add(x, y); err != nil {
+		t.Fatal(err)
+	}
+	b, err := Marshal(g)
+	if err != nil {
+		t.Errorf("Error printing graph: %v", err)
+	}
+	fst := fmt.Sprintf("\n%s", string(b))
+	fst = unmangleName(fst, x)
+	fst = unmangleName(fst, y)
+	fst = unmangleName(fst, z)
+
+	var x2, y2, z2 *gorgonia.Node
+
+	g2 := gorgonia.NewGraph()
+	x2 = gorgonia.NewScalar(g2, gorgonia.Float64, gorgonia.WithName("x"))
+	y2 = gorgonia.NewScalar(g2, gorgonia.Float64, gorgonia.WithName("y"))
+	if z2, err = gorgonia.Add(x2, y2); err != nil {
+		t.Fatal(err)
+	}
+	b2, err := Marshal(g2)
+	if err != nil {
+		t.Errorf("Error printing graph: %v", err)
+	}
+	snd := fmt.Sprintf("\n%s", string(b2))
+	snd = unmangleName(snd, x2)
+	snd = unmangleName(snd, y2)
+	snd = unmangleName(snd, z2)
+	assert.Equal(fst, snd, "XXX")
+	t.Logf("%v %v", z, z2)
+}
+
+func TestStressTest407(t *testing.T) {
+	for i := 0; i < 1024; i++ {
+		TestIssue_407(t)
+		if t.Failed() {
+			t.Errorf("Failed at iteration %d", i)
+			break
+		}
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/cznic/strutil v0.0.0-20181122101858-275e90344537/go.mod h1:AHHPPPXTw0
 github.com/cznic/xc v0.0.0-20181122101856-45b06973881e/go.mod h1:3oFoiOvCDBYH+swwf5+k/woVmWy7h1Fcyu8Qig/jjX0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/delaneyj/cogent v0.0.0-20180619184653-2fcea326194c h1:UliKg7JACWAXDW7yFdms6lLwOLK7H3uId3NG5z4f378=
+github.com/delaneyj/cogent v0.0.0-20180619184653-2fcea326194c/go.mod h1:hL/k6TDIq37bqQ6sySYVYw+Idnv0JkVmKsmedD5AduQ=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -50,6 +52,8 @@ github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/gorgonia-cfd5423e2acc2f8c2b86 v0.0.0-20200313070349-288c2a647837 h1:/7GLXOx1Cd15DDfNpIZguExr6Ui5e2vKVbCf8x52ls0=
+github.com/mattn/gorgonia-cfd5423e2acc2f8c2b86 v0.0.0-20200313070349-288c2a647837/go.mod h1:MGXCds9oIEtiTo7SSDV2qlEYxIFO0LdSOf4BlNJYr34=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -57,8 +61,11 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/seehuhn/mt19937 v0.0.0-20191220121156-d07252b9f9df h1:rhEzo7J+sDOLI5NulkwtescnyYMSt4J5mkxDMgQRjN4=
+github.com/seehuhn/mt19937 v0.0.0-20191220121156-d07252b9f9df/go.mod h1:w+IAy13Luqfsp+plFpT1RiqauADylJKmpkrWFwpjbsc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -114,9 +121,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorgonia.org/cu v0.9.0-beta h1:s4WQ6fiAGoErwIiXWHRB6Y9ydkx1vTTPwhWzoEZVePc=
 gorgonia.org/cu v0.9.0-beta/go.mod h1:RPEPIfaxxqUmeRe7T1T8a0NER+KxBI2McoLEXhP1Vd8=
-gorgonia.org/cu v0.9.3 h1:IkxE4NWXuZHqr8AnmgoB8WNQPZeD6u0EJNxYjDC0YgY=
 gorgonia.org/cu v0.9.3/go.mod h1:LgyAYDkN7HWhh8orGnCY2R8pP9PYbO44ivEbLMatkVU=
-gorgonia.org/dawson v1.1.0 h1:o7+eJ3SKi9sheH19lpOat//tDbg0Y+M9iY/lH79VHqY=
 gorgonia.org/dawson v1.1.0/go.mod h1:Px1mcziba8YUBIDsbzGwbKJ11uIblv/zkln4jNrZ9Ws=
 gorgonia.org/dawson v1.2.0 h1:hJ/aofhfkReSnJdSMDzypRZ/oWDL1TmeYOauBnXKdFw=
 gorgonia.org/dawson v1.2.0/go.mod h1:Px1mcziba8YUBIDsbzGwbKJ11uIblv/zkln4jNrZ9Ws=

--- a/internal/encoding/groups.go
+++ b/internal/encoding/groups.go
@@ -28,21 +28,41 @@ type Grouper interface {
 type Groups []Group
 
 // Upsert the GroupID in the groups
-func (g *Groups) Upsert(grp Group) {
-	for i := 0; i < len(*g); i++ {
-		if (*g)[i].ID == grp.ID {
-			return
+func (g Groups) Upsert(grp Group) Groups {
+	for i := 0; i < len(g); i++ {
+		if (g)[i].ID == grp.ID {
+			return g
 		}
 	}
-	*g = append(*g, grp)
+	return append(g, grp)
 }
 
 // Have returns true if GroupID is in groups
-func (g *Groups) Have(grp Group) bool {
-	for i := 0; i < len(*g); i++ {
-		if (*g)[i].ID == grp.ID {
+func (g Groups) Have(grp Group) bool {
+	for i := 0; i < len(g); i++ {
+		if (g)[i].ID == grp.ID {
 			return true
 		}
 	}
 	return false
 }
+
+/* Groups by default sort by the group ID */
+
+// Len returns the length of a bag of groups
+func (g Groups) Len() int { return len(g) }
+
+// Less checks if an ID is less than or not
+func (g Groups) Less(i, j int) bool { return g[i].ID < g[j].ID }
+
+// Swap swaps the elements
+func (g Groups) Swap(i, j int) { g[i], g[j] = g[j], g[i] }
+
+// ByName is a sorting for a slice of groups, where the groups are sorted by name
+type ByName []Group
+
+func (g ByName) Len() int { return len(g) }
+
+func (g ByName) Less(i, j int) bool { return g[i].Name < g[j].Name }
+
+func (g ByName) Swap(i, j int) { g[i], g[j] = g[j], g[i] }

--- a/internal/encoding/groups_test.go
+++ b/internal/encoding/groups_test.go
@@ -1,20 +1,23 @@
 package encoding
 
-import "testing"
+import (
+	"sort"
+	"testing"
+)
 
 func TestGroups(t *testing.T) {
 	var g Groups
 	g1 := NewGroup("g1")
 	g2 := NewGroup("g2")
-	g.Upsert(g1)
+	g = g.Upsert(g1)
 	if len(g) != 1 {
 		t.Fail()
 	}
-	g.Upsert(g1)
+	g = g.Upsert(g1)
 	if len(g) != 1 {
 		t.Fail()
 	}
-	g.Upsert(g2)
+	g = g.Upsert(g2)
 	if len(g) != 2 {
 		t.Fail()
 	}
@@ -29,6 +32,46 @@ func TestGroups(t *testing.T) {
 	}
 	if g.Have(NewGroup("g2")) {
 		t.Fail()
+	}
+
+}
+
+func TestSorts(t *testing.T) {
+	var gs Groups
+	g1 := NewGroup("A")
+	g2 := NewGroup("B")
+
+	gs = gs.Upsert(g2)
+	gs = gs.Upsert(g1)
+
+	t.Logf("%v", gs)
+	sort.Sort(gs)
+	if gs[0] != g1 {
+		t.Errorf("Groups: Expected the first element to be Group A. g1's ID %d", g1.ID)
+	}
+	if gs[1] != g2 {
+		t.Errorf("Groups: Expected the second element to be Group B, g2's ID %d", g2.ID)
+	}
+
+	t.Logf("%v", gs)
+
+	// reset
+
+	gs = gs[:0]
+	gs = gs.Upsert(g2)
+	gs = gs.Upsert(g1)
+
+	// check that resets work
+	if gs[0] != g2 {
+		t.Fatal("Must not proceed. Reset failed")
+	}
+
+	sort.Sort(ByName(gs))
+	if gs[0] != g1 {
+		t.Errorf("ByName: Expected the first element to be Group A. g1's name: %q", g1.Name)
+	}
+	if gs[1] != g2 {
+		t.Errorf("ByName: Expected the second element to be Group B. g2's name: %q", g2.Name)
 	}
 
 }

--- a/nn.go
+++ b/nn.go
@@ -184,7 +184,7 @@ func Rectify(x *Node) (retVal *Node, err error) {
 	if retVal, err = ApplyOp(cmp, x, zero); err != nil {
 		return nil, errors.Wrap(err, applyOpFail)
 	}
-	retVal.groups.Upsert(group)
+	retVal.groups = retVal.groups.Upsert(group)
 
 	return HadamardProd(x, retVal)
 }
@@ -267,7 +267,7 @@ func Conv2d(im, filter *Node, kernelShape tensor.Shape, pad, stride, dilation []
 	if colIm, err = Im2Col(im, kernelShape, pad, stride, dilation); err != nil {
 		return
 	}
-	colIm.groups.Upsert(group)
+	colIm.groups = colIm.groups.Upsert(group)
 
 	layer := filter.Shape()[0]
 	kernel := filter.Shape()[1]
@@ -278,7 +278,7 @@ func Conv2d(im, filter *Node, kernelShape tensor.Shape, pad, stride, dilation []
 	if flattened, err = Reshape(filter, tensor.Shape{layer, kernel * row * col}); err != nil {
 		return
 	}
-	flattened.groups.Upsert(group)
+	flattened.groups = flattened.groups.Upsert(group)
 
 	// extract patch
 	batch := colIm.Shape()[0]
@@ -290,7 +290,7 @@ func Conv2d(im, filter *Node, kernelShape tensor.Shape, pad, stride, dilation []
 	if patch, err = Reshape(colIm, tensor.Shape{batch * m * n, z}); err != nil {
 		return
 	}
-	patch.groups.Upsert(group)
+	patch.groups = patch.groups.Upsert(group)
 
 	op := linAlgBinOp{
 		āBinaryOperator: matMulOperator,
@@ -301,16 +301,16 @@ func Conv2d(im, filter *Node, kernelShape tensor.Shape, pad, stride, dilation []
 	if colImLayer, err = ApplyOp(op, patch, flattened); err != nil {
 		return
 	}
-	colImLayer.groups.Upsert(group)
+	colImLayer.groups = colImLayer.groups.Upsert(group)
 
 	// now reshape and transpose the values back into the original order
 	var res *Node
 	if res, err = Reshape(colImLayer, tensor.Shape{batch, m, n, layer}); err != nil {
 		return
 	}
-	res.groups.Upsert(group)
+	res.groups = res.groups.Upsert(group)
 	ret, err := Transpose(res, 0, 3, 1, 2)
-	ret.groups.Upsert(group)
+	ret.groups = ret.groups.Upsert(group)
 	return ret, err
 }
 
@@ -356,7 +356,7 @@ func MaxPool2D(x *Node, kernel tensor.Shape, pad, stride []int) (*Node, error) {
 
 	op := newMaxPoolOp(xShape, kernel, pad, stride)
 	retVal, err := ApplyOp(op, x)
-	retVal.groups.Upsert(group)
+	retVal.groups = retVal.groups.Upsert(group)
 	return retVal, err
 }
 

--- a/node.go
+++ b/node.go
@@ -197,10 +197,11 @@ func WithShape(shp ...int) NodeConsOpt {
 	s := tensor.Shape(tensor.BorrowInts(len(shp)))
 	copy(s, shp)
 	f := func(n *Node) {
+		if n.t == nil && n.shape == nil {
+			n.shape = s
+			return
+		}
 		nd := n.Dims()
-		// if nd == 1 && s.IsVector() {
-		// 	goto safe
-		// }
 		isVec := s.IsColVec() || s.IsRowVec()
 		acceptVec := (isVec && (nd == 1))
 		sameDims := nd == s.Dims()
@@ -209,7 +210,6 @@ func WithShape(shp ...int) NodeConsOpt {
 		if !acceptVec && !sameDims && !acceptScalar {
 			panic(fmt.Sprintf("Node %v, has %d dimensions(Shape: %v). Input shape is %v, which has %d dimensions", n, n.Dims(), n.shape, s, s.Dims()))
 		}
-		// safe:
 		n.shape = s
 	}
 	return f
@@ -258,6 +258,8 @@ func newNode(opts ...NodeConsOpt) *Node {
 	n := borrowNode()
 	n.dataOn = CPU
 	n.id = -1
+	n.t = nil
+	n.shape = nil
 
 	for _, opt := range opts {
 		opt(n)

--- a/node.go
+++ b/node.go
@@ -229,7 +229,7 @@ func WithGroupName(name string) NodeConsOpt {
 // withGroup is a node construction option to group a *Node within a particular group. This option is useful for debugging with graphs.
 func withGroup(group encoding.Group) NodeConsOpt {
 	f := func(n *Node) {
-		n.groups.Upsert(group)
+		n.groups = n.groups.Upsert(group)
 	}
 	return f
 }
@@ -245,11 +245,11 @@ func (n *Node) Groups() encoding.Groups {
 
 	switch {
 	case isConst:
-		n.groups.Upsert(encoding.ConstantCluster)
+		n.groups = n.groups.Upsert(encoding.ConstantCluster)
 	case isInput:
-		n.groups.Upsert(encoding.InputCluster)
+		n.groups = n.groups.Upsert(encoding.InputCluster)
 	default:
-		n.groups.Upsert(encoding.ExprGraphCluster)
+		n.groups = n.groups.Upsert(encoding.ExprGraphCluster)
 	}
 	return n.groups
 }

--- a/op.go
+++ b/op.go
@@ -199,7 +199,7 @@ func ApplyOp(op Op, children ...*Node) (retVal *Node, err error) {
 	var s tensor.Shape
 	if s, err = op.InferShape(ds...); err == nil {
 		shapeLogf("inferred shape %v", s)
-		retVal = NewUniqueNode(WithType(retType), WithOp(op), WithChildren(children), In(g), WithShape(s...))
+		retVal = NewUniqueNode(WithOp(op), WithChildren(children), In(g), WithShape(s...), WithType(retType))
 	} else {
 		err = errors.Wrapf(err, "Failed to infer shape. Op: %v", op)
 		// retVal = newUniqueNode(withType(retType), withOp(op), withChildren(children), withGraph(g))

--- a/op.go
+++ b/op.go
@@ -199,7 +199,7 @@ func ApplyOp(op Op, children ...*Node) (retVal *Node, err error) {
 	var s tensor.Shape
 	if s, err = op.InferShape(ds...); err == nil {
 		shapeLogf("inferred shape %v", s)
-		retVal = NewUniqueNode(WithOp(op), WithChildren(children), In(g), WithShape(s...), WithType(retType))
+		retVal = NewUniqueNode(WithType(retType), WithOp(op), WithChildren(children), In(g), WithShape(s...))
 	} else {
 		err = errors.Wrapf(err, "Failed to infer shape. Op: %v", op)
 		// retVal = newUniqueNode(withType(retType), withOp(op), withChildren(children), withGraph(g))

--- a/op_reduction.go
+++ b/op_reduction.go
@@ -52,24 +52,19 @@ func reductionInferShape(along []int, in tensor.Shape) (tensor.Shape, error) {
 		if d >= shape.Dims() {
 			return nil, fmt.Errorf("shape error, along %d is not a valid axis for shape %v", d, in)
 		}
-		shape[d] = 1
+		shape[d] = 0
 	}
-	// special cases: if all dimensions are 1 -> ScalarShape, if exactly one dimension is != 1 -> vector
-	vecD := 0
-	numNot1 := 0
+
+	var dims []int
 	for _, d := range shape {
-		if d != 1 {
-			vecD = d
-			numNot1++
-			if numNot1 > 1 {
-				return shape, nil
-			}
+		if d != 0 {
+			dims = append(dims, d)
 		}
 	}
-	if numNot1 == 0 {
+	if len(dims) == 0 {
 		return tensor.ScalarShape(), nil
 	}
-	return tensor.Shape{vecD}, nil
+	return tensor.Shape(dims), nil
 }
 
 func reductionDo(op Op, s string, f func(*tensor.Dense, ...int) (*tensor.Dense, error), along []int, inputs ...Value) (retVal Value, err error) {

--- a/op_reduction.go
+++ b/op_reduction.go
@@ -20,7 +20,7 @@ import (
 
 func reductionType(d int, along []int) hm.Type {
 	a := hm.TypeVariable('a')
-	t := makeTensorType(d, a)
+	t := makeTensorType(d-len(along), a)
 
 	axes := make(map[int]bool)
 	for _, axis := range along {

--- a/op_reduction_test.go
+++ b/op_reduction_test.go
@@ -254,7 +254,7 @@ func TestMaxOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Max,
 			along:     []int{0},
-			wantShape: []int{1, 2, 2, 2},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{9, 10, 11, 12, 13, 14, 15, 16},
 		},
 		{
@@ -263,7 +263,7 @@ func TestMaxOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Max,
 			along:     []int{1},
-			wantShape: []int{2, 1, 2, 2},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{5, 6, 7, 8, 13, 14, 15, 16},
 		},
 		{
@@ -272,7 +272,7 @@ func TestMaxOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Max,
 			along:     []int{2},
-			wantShape: []int{2, 2, 1, 2},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{3, 4, 7, 8, 11, 12, 15, 16},
 		},
 		{
@@ -281,7 +281,7 @@ func TestMaxOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Max,
 			along:     []int{3},
-			wantShape: []int{2, 2, 2, 1},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{2, 4, 6, 8, 10, 12, 14, 16},
 		},
 		{
@@ -290,7 +290,7 @@ func TestMaxOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Max,
 			along:     []int{1, 3},
-			wantShape: []int{2, 1, 2, 1},
+			wantShape: []int{2, 2},
 			wantData:  []float32{6, 8, 14, 16},
 		},
 		{
@@ -342,7 +342,7 @@ func TestSumOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Sum,
 			along:     []int{0},
-			wantShape: []int{1, 2, 2, 2},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{10, 12, 14, 16, 18, 20, 22, 24},
 		},
 		{
@@ -351,7 +351,7 @@ func TestSumOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Sum,
 			along:     []int{1},
-			wantShape: []int{2, 1, 2, 2},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{6, 8, 10, 12, 22, 24, 26, 28},
 		},
 		{
@@ -360,7 +360,7 @@ func TestSumOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Sum,
 			along:     []int{2},
-			wantShape: []int{2, 2, 1, 2},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{4, 6, 12, 14, 20, 22, 28, 30},
 		},
 		{
@@ -369,7 +369,7 @@ func TestSumOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Sum,
 			along:     []int{3},
-			wantShape: []int{2, 2, 2, 1},
+			wantShape: []int{2, 2, 2},
 			wantData:  []float32{3, 7, 11, 15, 19, 23, 27, 31},
 		},
 		{
@@ -378,7 +378,7 @@ func TestSumOp(t *testing.T) {
 			inData:    []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			op:        Sum,
 			along:     []int{1, 3},
-			wantShape: []int{2, 1, 2, 1},
+			wantShape: []int{2, 2},
 			wantData:  []float32{14, 22, 46, 54},
 		},
 		{
@@ -562,12 +562,12 @@ func TestFollowupOp(t *testing.T) {
 	Xn := NewTensor(g, tensor.Float64, 4, WithShape(2, 2, 2, 2), WithInit(RangedFrom(1)))
 	mx := Must(Max(Xn, 1, 2))
 	sx := Must(Sum(Xn, 1, 2))
-	y := NewTensor(g, tensor.Float64, 4, WithShape(2, 1, 1, 2), WithInit(RangedFrom(1)))
+	y := NewTensor(g, tensor.Float64, 2, WithShape(2, 2), WithInit(RangedFrom(1)))
 
 	amx := Must(Add(mx, y))
 	asx := Must(Add(sx, y))
-	assert.Equal(t, amx.Shape(), tensor.Shape{2, 1, 1, 2})
-	assert.Equal(t, asx.Shape(), tensor.Shape{2, 1, 1, 2})
+	assert.Equal(t, amx.Shape(), tensor.Shape{2, 2})
+	assert.Equal(t, asx.Shape(), tensor.Shape{2, 2})
 	vm := NewTapeMachine(g)
 	defer vm.Close()
 	err := vm.RunAll()


### PR DESCRIPTION
The reductionInferShape currently doesn't respect along initially.
It aggressively squeezes dimensions. Not only does it affect normal tensor operation, but also it breaks the backprop autoDiff algorithm sometimes when the network containing BroadcastAdd, resulting in crash when calling Grad().

The change tries to strictly respect the parameter along, e.g.,
(100, 1) along 0, reduction to shape (1) instead ()
(1, 64, 1, 64) along 3 will reduce to (1, 64, 1)
(64, 1, 3, 2) along (2,3) will reduce to (64, 1).