### PR TITLE
Fix solver not updating weights correctly

### DIFF
--- a/differentiation.go
+++ b/differentiation.go
@@ -23,18 +23,14 @@ func forwardDiffAnalysis(outputs, sortedNodes Nodes) (retVal NodeSet, err error)
 	enterLogScope()
 	defer leaveLogScope()
 
-	sane := outputs.AllSameGraph()
-	if !sane {
+	if !outputs.AllSameGraph() {
 		return nil, errors.New("The supplied output Nodes are not the same graph")
 	}
 
-	// diffSet := outputs.Set()
 	diffSet := outputs.mapSet()
 
 	symdiffLogf("Diff Set: %v", diffSet)
 	symdiffLogf("%d", sortedNodes)
-	// for i := len(sortedNodes) - 1; i ⩾ 0; i-- {
-	// 	n := sortedNodes[i]
 	for _, n := range sortedNodes {
 		if diffSet.Contains(n) && !n.isInput() {
 			diffs := n.diffWRT()
@@ -42,7 +38,6 @@ func forwardDiffAnalysis(outputs, sortedNodes Nodes) (retVal NodeSet, err error)
 				d := diffs[j]
 				if d {
 					symdiffLogf("Adding %x to  differentiable set", child.ID())
-					// diffSet = append(diffSet, child)
 					diffSet.Add(child)
 				}
 			}
@@ -58,20 +53,16 @@ func backwardDiffAnalysis(wrt, sortedNodes Nodes) (retVal NodeSet, err error) {
 	enterLogScope()
 	defer leaveLogScope()
 
-	sane := wrt.AllSameGraph()
-	if !sane {
+	if !wrt.AllSameGraph() {
 		return nil, errors.New("The supplied output Nodes are not the same graph")
 	}
 
-	// diffSet := wrt.Set()
 	diffSet := wrt.mapSet()
-	// autodiffLogf("Diff Set: %d", diffSet)
 	symdiffLogf("wrt:%d diffset: %d", len(wrt), len(diffSet))
 	symdiffLogf("%v", diffSet)
 	symdiffLogf("sorted: %d", sortedNodes)
 
 	enterLogScope()
-	// for _, n := range sortedNodes {
 	for i := len(sortedNodes) - 1; i >= 0; i-- {
 		n := sortedNodes[i]
 		symdiffLogf("working on %v. Has %d children", n, len(n.children))
@@ -104,8 +95,6 @@ func backwardDiffAnalysis(wrt, sortedNodes Nodes) (retVal NodeSet, err error) {
 			g := n.g
 			for _, child := range n.children {
 				parents := graph.NodesOf(g.To(child.ID()))
-
-				// symdiffLogf("parents of %v: %v", child, graphNodeToNode(parents))
 				if len(parents) == 1 && len(child.children) > 0 {
 					leaveLogScope()
 					return nil, errors.Errorf("Being unable to differentiate %v would leave a portion of the graph unreachable. Unable to continue", n)
@@ -121,7 +110,6 @@ func backwardDiffAnalysis(wrt, sortedNodes Nodes) (retVal NodeSet, err error) {
 			d := diffs[j]
 			if diffSet.Contains(child) && d {
 				symdiffLogf("Adding %x to differentiable set", child.ID())
-				// diffSet = append(diffSet, n)
 				diffSet.Add(n)
 				break inner
 			}

--- a/op_math.go
+++ b/op_math.go
@@ -191,7 +191,7 @@ func (op elemBinOp) InferShape(inputs ...DimSizer) (retVal tensor.Shape, err err
 //		c = a ** b
 // The result of the differentiation wrt to a and b would be:
 // 		dc/da = b * a ** (b-1)
-// 		dc/db = <insert exp rule expansion here.. don't quite remember it> //TODO
+// 		dc/db = a ** b * ln(a)
 //
 // However, operators like < and > are NOT differentiable
 //

--- a/solvers.go
+++ b/solvers.go
@@ -519,7 +519,7 @@ func (s *AdamSolver) Step(model []ValueGrad) (err error) {
 
 			if s.useL2Reg {
 				var l2regs tensor.Tensor
-				if l2regs, err = tensor.Mul(l2reg, w); err != nil {
+				if l2regs, err = tensor.Mul(w, l2reg); err != nil {
 					return errors.Wrap(err, pointWiseMulFail)
 				}
 
@@ -531,7 +531,7 @@ func (s *AdamSolver) Step(model []ValueGrad) (err error) {
 			}
 
 			if s.batch > 1 {
-				if _, err = tensor.Mul(onePerBatch, g, tensor.UseUnsafe()); err != nil {
+				if _, err = tensor.Mul(g, onePerBatch, tensor.UseUnsafe()); err != nil {
 					return errors.Wrap(err, pointWiseMulFail)
 				}
 			}
@@ -549,7 +549,7 @@ func (s *AdamSolver) Step(model []ValueGrad) (err error) {
 
 			// equation(1)
 			t1 := g.Clone().(*tensor.Dense)
-			if _, err = tensor.Mul(omβ1, t1, tensor.UseUnsafe()); err != nil {
+			if _, err = tensor.Mul(t1, omβ1, tensor.UseUnsafe()); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
@@ -557,17 +557,17 @@ func (s *AdamSolver) Step(model []ValueGrad) (err error) {
 			if _, err = tensor.Mul(g, g, tensor.UseUnsafe()); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
-			if _, err = tensor.Mul(omβ2, g, tensor.UseUnsafe()); err != nil {
+			if _, err = tensor.Mul(g, omβ2, tensor.UseUnsafe()); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
 			// equation (1)
-			if _, err = tensor.Mul(beta1, m, tensor.WithIncr(t1)); err != nil {
+			if _, err = tensor.Mul(m, beta1, tensor.WithIncr(t1)); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
 			// equation (2)
-			if _, err = tensor.Mul(beta2, v, tensor.WithIncr(g)); err != nil {
+			if _, err = tensor.Mul(v, beta2, tensor.WithIncr(g)); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
@@ -580,11 +580,11 @@ func (s *AdamSolver) Step(model []ValueGrad) (err error) {
 			mHats := t1.Clone().(*tensor.Dense)
 			vHats := g.Clone().(*tensor.Dense)
 
-			if _, err = tensor.Mul(correctionV1, mHats, tensor.UseUnsafe()); err != nil {
+			if _, err = tensor.Mul(mHats, correctionV1, tensor.UseUnsafe()); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
-			if _, err = tensor.Mul(correctionV2, vHats, tensor.UseUnsafe()); err != nil {
+			if _, err = tensor.Mul(vHats, correctionV2, tensor.UseUnsafe()); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
@@ -593,11 +593,11 @@ func (s *AdamSolver) Step(model []ValueGrad) (err error) {
 				return // TODO: rewrite this to use InvSqrt
 			}
 
-			if _, err = tensor.Add(eps, vHats, tensor.UseUnsafe()); err != nil {
+			if _, err = tensor.Add(vHats, eps, tensor.UseUnsafe()); err != nil {
 				return
 			}
 
-			if _, err = tensor.Mul(eta, mHats, tensor.UseUnsafe()); err != nil {
+			if _, err = tensor.Mul(mHats, eta, tensor.UseUnsafe()); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
@@ -803,7 +803,7 @@ func (s *VanillaSolver) Step(model []ValueGrad) (err error) {
 			}
 
 			if s.useL2Reg {
-				if l2regs, err = tensor.Mul(l2reg, w); err != nil {
+				if l2regs, err = tensor.Mul(w, l2reg); err != nil {
 					return errors.Wrap(err, pointWiseMulFail)
 				}
 
@@ -815,7 +815,7 @@ func (s *VanillaSolver) Step(model []ValueGrad) (err error) {
 			}
 
 			if s.batch > 1 {
-				if _, err = tensor.Mul(onePerBatch, g, tensor.UseUnsafe()); err != nil {
+				if _, err = tensor.Mul(g, onePerBatch, tensor.UseUnsafe()); err != nil {
 					return errors.Wrap(err, pointWiseMulFail)
 				}
 			}
@@ -826,7 +826,7 @@ func (s *VanillaSolver) Step(model []ValueGrad) (err error) {
 				}
 			}
 
-			if _, err = tensor.Mul(eta, g, tensor.UseUnsafe()); err != nil {
+			if _, err = tensor.Mul(g, eta, tensor.UseUnsafe()); err != nil {
 				return errors.Wrap(err, pointWiseMulFail)
 			}
 
@@ -1017,7 +1017,7 @@ func (s *Momentum) Step(model []ValueGrad) (err error) {
 			}
 
 			if s.useL2Reg {
-				if l2regs, err = tensor.Mul(l2reg, cw); err != nil {
+				if l2regs, err = tensor.Mul(cw, l2reg); err != nil {
 					return errors.Wrap(err, pointWiseMulFail)
 				}
 
@@ -1029,7 +1029,7 @@ func (s *Momentum) Step(model []ValueGrad) (err error) {
 			}
 
 			if s.batch > 1 {
-				if _, err = tensor.Mul(onePerBatch, g, tensor.UseUnsafe()); err != nil {
+				if _, err = tensor.Mul(g, onePerBatch, tensor.UseUnsafe()); err != nil {
 					return errors.Wrap(err, pointWiseMulFail)
 				}
 			}


### PR DESCRIPTION
Due to the bug in tensor.Mul when gorgonia/tensor#70, the AdamSolver/VanillaSolver/Momentum  are affected when using scalar as the first argument in tensor.Mul call.
Including some cleanup of typos and unused commented out code.