### PR TITLE
Fix shape check when applying reshape op

### DIFF
--- a/op_tensor.go
+++ b/op_tensor.go
@@ -1156,7 +1156,7 @@ func (op reshapeOp) Do(vals ...Value) (Value, error) {
 				return nil, errors.Wrapf(err, cloneFail, vals[0])
 			}
 		}
-		if !val.Shape().Eq(op.from) {
+		if val.Shape().TotalSize() != op.from.TotalSize() {
 			return nil, errors.Errorf("Shape mismatch. Input shape is %v. Expected %v", val.Shape(), op.from)
 		}
 


### PR DESCRIPTION
It should still work since the val is reshaped in the next line, so the
geometry of the shape is not important at this point