### PR TITLE
fix(tanhdiff): add explicit cast for tanh test

### DIFF
--- a/operatorPointwise_unary_test.go
+++ b/operatorPointwise_unary_test.go
@@ -430,7 +430,7 @@ func TestTanhDiff(t *testing.T) {
 		t.Error(err)
 	}
 
-	correct := 1.0 - (math.Tanh(v) * math.Tanh(v)) // I'm surprised Golang doesn't have a secant function!
+	correct := 1.0 - (float64(math.Tanh(v)) * float64(math.Tanh(v))) // I'm surprised Golang doesn't have a secant function!
 	assert.Equal(correct, x.boundTo.(*dualValue).d.Data())
 
 	// Tensor edition


### PR DESCRIPTION
The spec mention that the behavior can differ accross different
architecture.
See https://github.com/golang/go/issues/44528 for more details