### PR TITLE
Fix adam

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off

--- a/solvers_test.go
+++ b/solvers_test.go
@@ -325,7 +325,7 @@ func TestAdamSolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	solver := NewAdamSolver()
+	solver := NewAdamSolver(WithLearnRate(0.1))
 
 	maxIterations := 1000
 
@@ -353,35 +353,88 @@ func TestAdamSolver(t *testing.T) {
 	assert.InDelta(0, costFloat, costThreshold)
 }
 
-func TestAdamSolver2(t *testing.T) {
-	c := require.New(t)
-	g := NewGraph()
-
-	weights := NewTensor(g, tensor.Float32, 2, WithShape(4, 1), WithInit(Ones()), WithName("weights"))
-	input := NewTensor(g, tensor.Float32, 2, WithShape(1, 4), WithName("x"))
-
-	fc := Must(Mul(input, weights))
-	loss := Must(Mean(fc))
-
-	_, err := Grad(loss, weights)
-	c.NoError(err)
-
-	solver := NewAdamSolver(WithLearnRate(0.1))
-	vm := NewTapeMachine(g, BindDualValues(weights))
-
-	for d := float32(0.0); d < 1.0; d += 0.1 {
-		Let(input, tensor.New(
-			tensor.WithShape(1, 4),
-			tensor.WithBacking([]float32{d, d, d, d}),
-		))
-		c.NoError(vm.RunAll())
-
-		c.NoError(solver.Step([]ValueGrad{weights}))
-
-		vm.Reset()
+func TestAdamSolverPrecision(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		learnRate      float64
+		inputStart     float32
+		inputEnd       float32
+		inputIncrement float32
+		size           int
+		dtype          tensor.Dtype
+		expectedOutput interface{}
+	}{
+		{
+			desc:           "Example-float32-1",
+			learnRate:      0.1,
+			inputStart:     0.0,
+			inputEnd:       1.0,
+			inputIncrement: 0.1,
+			size:           4,
+			dtype:          tensor.Float32,
+			expectedOutput: []float32{0.18293014, 0.18293014, 0.18293014, 0.18293014},
+		},
+		{
+			desc:           "Example-float64-1",
+			learnRate:      0.1,
+			inputStart:     0.0,
+			inputEnd:       1.0,
+			inputIncrement: 0.1,
+			size:           8,
+			dtype:          tensor.Float64,
+			expectedOutput: []float64{0.18293561851374684, 0.18293561851374684, 0.18293561851374684, 0.18293561851374684, 0.18293561851374684, 0.18293561851374684, 0.18293561851374684, 0.18293561851374684},
+		},
 	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			c := require.New(t)
+			g := NewGraph()
 
-	c.Equal([]float32{0.18293014, 0.18293014, 0.18293014, 0.18293014}, weights.Value().Data())
+			weights := NewTensor(g, tC.dtype, 2, WithShape(tC.size, 1), WithInit(Ones()), WithName("weights"))
+			input := NewTensor(g, tC.dtype, 2, WithShape(1, tC.size), WithName("x"))
+
+			fc := Must(Mul(input, weights))
+			loss := Must(Mean(fc))
+
+			_, err := Grad(loss, weights)
+			c.NoError(err)
+
+			solver := NewAdamSolver(WithLearnRate(tC.learnRate))
+			vm := NewTapeMachine(g, BindDualValues(weights))
+
+			for d := tC.inputStart; d < tC.inputEnd; d += tC.inputIncrement {
+				var backing interface{}
+
+				if tC.dtype == tensor.Float32 {
+					arr := make([]float32, tC.size)
+					for i := range arr {
+						arr[i] = float32(d)
+					}
+
+					backing = arr
+				} else {
+					arr := make([]float64, tC.size)
+					for i := range arr {
+						arr[i] = float64(d)
+					}
+
+					backing = arr
+				}
+
+				Let(input, tensor.New(
+					tensor.WithShape(1, tC.size),
+					tensor.WithBacking(backing),
+				))
+				c.NoError(vm.RunAll())
+
+				c.NoError(solver.Step([]ValueGrad{weights}))
+
+				vm.Reset()
+			}
+
+			c.Equal(tC.expectedOutput, weights.Value().Data())
+		})
+	}
 }
 
 func TestBarzilaiBorweinSolver(t *testing.T) {

--- a/solvers_test.go
+++ b/solvers_test.go
@@ -432,7 +432,12 @@ func TestAdamSolverPrecision(t *testing.T) {
 				vm.Reset()
 			}
 
-			c.Equal(tC.expectedOutput, weights.Value().Data())
+			maxDiff := 1e-15
+			if tC.dtype == tensor.Float32 {
+				maxDiff = 1e-7
+			}
+
+			c.InDeltaSlicef(tC.expectedOutput, weights.Value().Data(), maxDiff, "!=")
 		})
 	}
 }


### PR DESCRIPTION
The problem was that it was increasing the weights twice in every step.

I verified the output against this pytorch program and it matches:
```
import torch
import numpy as np

model = torch.nn.Linear(4, 1, bias=False)
with torch.no_grad():
     model.weight.copy_(torch.ones_like(model.weight))

optimizer = torch.optim.Adam([model.weight], lr=0.1)

for i, epoch in enumerate(np.arange(0.0, 1.0, 0.1)):
    optimizer.zero_grad()
    output = model(torch.autograd.Variable(torch.tensor([epoch, epoch, epoch, epoch]).float()))
    # output.retain_grad()

    loss = torch.mean(output)
    # loss.retain_grad()

    loss.backward()
    optimizer.step()

    print("#", i, model.weight.data)
```
