### PR TITLE
Fix for CUDA stuff not compiling due to trying to use the deprecated `tensor.Memory.Pointer` function

### DIFF
--- a/cuda.go
+++ b/cuda.go
@@ -138,7 +138,7 @@ func (m *ExternMetadata) GetFromValue(dev Device, v Value) (tensor.Memory, error
 	}
 	ptr := cu.DevicePtr(mem.Uintptr())
 	ctx := m.engines[dev].Context()
-	ctx.MemcpyHtoD(ptr, v.Pointer(), memsize)
+	ctx.MemcpyHtoD(ptr, valueToPointer(v), memsize)
 	return cu.DevicePtr(ptr), nil
 }
 
@@ -183,7 +183,7 @@ func (m *ExternMetadata) Transfer(toDev, fromDev Device, v Value, synchronous bo
 		if mem, err = m.Get(toDev, memsize); err != nil {
 			return
 		}
-		ctx.MemcpyHtoD(cu.DevicePtr(mem.Uintptr()), v.Pointer(), memsize)
+		ctx.MemcpyHtoD(cu.DevicePtr(mem.Uintptr()), valueToPointer(v), memsize)
 		return makeValueFromMem(TypeOf(v), v.Shape(), mem)
 
 	case fromDev != CPU && toDev == CPU:
@@ -196,7 +196,7 @@ func (m *ExternMetadata) Transfer(toDev, fromDev Device, v Value, synchronous bo
 		if retVal, err = makeValue(TypeOf(v), v.Shape()); err != nil {
 			return
 		}
-		ctx.MemcpyDtoH(retVal.Pointer(), cu.DevicePtr(v.Uintptr()), memsize)
+		ctx.MemcpyDtoH(valueToPointer(retVal), cu.DevicePtr(v.Uintptr()), memsize)
 		return
 	case fromDev == toDev:
 		return v, nil

--- a/values_utils.go
+++ b/values_utils.go
@@ -6,6 +6,7 @@ import (
 	"github.com/chewxy/hm"
 	"github.com/pkg/errors"
 	"gorgonia.org/tensor"
+	"unsafe"
 )
 
 // TypeOf returns the Type of the value
@@ -245,4 +246,9 @@ func setEngine(v Value, e tensor.Engine) {
 	case tensor.Tensor:
 		tensor.WithEngine(e)(vv)
 	}
+}
+
+// I think that all values are supposed to have the pointer method but they don't seem to so to just fix this for now this appears to work
+func valueToPointer(v Value) unsafe.Pointer{
+	return unsafe.Pointer(v.Uintptr())
 }


### PR DESCRIPTION
# The Problem
So when I try to run with build tag cuda, it won't compile. It looks like the interface `Memory` in package `gorgonia.tensor` is supposed to declare a function `Pointer` (or at least this package expects it to). When I added that function to the interface it broke many things.

After further investigation, it looks like the `Pointer` method was actually removed from the tensor package. So I guess this might actually be the correct way to fix the problem.

# My Fix
I have just added a function that converts a `Value` into an `unsafe.Pointer`. This may be a bad way to do this, but it seems to work correctly for me.

# My package versions
`gorgonia v0.9.17`
`tensor v0.9.24`
`cu v0.9.4`

# Tests
I ran `go test` in the gorgonia directory and it passed. I think this problem might have slipped through the automated tests if they are not testing stuff with the `cuda` build tag. Maby this should be added?