### PR TITLE
Add unary ops for ints

### DIFF
--- a/math.go
+++ b/math.go
@@ -33,6 +33,23 @@ func _cubef32(x float32) float32 { return x * x * x }
 func _negf32(x float32) float32 { return -x }
 func _negf64(x float64) float64 { return -x }
 
+func _negi64(x int64) int64 { return -x }
+func _negi32(x int32) int32 { return -x }
+
+func _absi64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func _absi32(x int32) int32 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 /* TODO: write optimized versions of these */
 
 // bounds acquired with this:

--- a/op_math.go
+++ b/op_math.go
@@ -399,6 +399,10 @@ func newElemUnaryOp(op ʘUnaryOperatorType, a *Node) elemUnaryOp {
 		operator = sf32UnaryOperators[op]
 	case Float64:
 		operator = sf64UnaryOperators[op]
+	case Int64:
+		operator = si64UnaryOperators[op]
+	case Int32:
+		operator = si32UnaryOperators[op]
 	}
 
 	return elemUnaryOp{

--- a/operatorPointwise_unary.go
+++ b/operatorPointwise_unary.go
@@ -25,6 +25,8 @@ type ʘUnaryOperator interface {
 
 type sf32UnaryOperator func(float32) float32
 type sf64UnaryOperator func(float64) float64
+type si64UnaryOperator func(int64) int64
+type si32UnaryOperator func(int32) int32
 
 // unaryCheckApply checks in a interface is fulfilled. If it is, that engine is used instead
 func unaryCheckApply(op ʘUnaryOperator, t tensor.Tensor, opts ...tensor.FuncOpt) (retVal tensor.Tensor, err error) {
@@ -95,6 +97,10 @@ func unaryCheckApply(op ʘUnaryOperator, t tensor.Tensor, opts ...tensor.FuncOpt
 		fn = (func(float64) float64)(*opFn)
 	case *sf32UnaryOperator:
 		fn = (func(float32) float32)(*opFn)
+	case *si64UnaryOperator:
+		fn = (func(int64) int64)(*opFn)
+	case *si32UnaryOperator:
+		fn = (func(int32) int32)(*opFn)
 	}
 
 	return t.Apply(fn, opts...)

--- a/operatorPointwise_unary_const.go
+++ b/operatorPointwise_unary_const.go
@@ -69,6 +69,14 @@ var (
 	log1pf32    = sf32UnaryOperator(math32.Log1p)
 	expm1f32    = sf32UnaryOperator(math32.Expm1)
 	softplusf32 = sf32UnaryOperator(_softplusf32)
+
+	/* Int64 - only neg and abs are meaningful for integers */
+	negi64 = si64UnaryOperator(_negi64)
+	absi64 = si64UnaryOperator(_absi64)
+
+	/* Int32 */
+	negi32 = si32UnaryOperator(_negi32)
+	absi32 = si32UnaryOperator(_absi32)
 )
 
 type ʘUnaryOperatorType byte
@@ -200,4 +208,53 @@ var sf32UnaryOperators = [maxʘUnaryOperator]*sf32UnaryOperator{
 	&log1pf32,
 	&expm1f32,
 	&softplusf32,
+}
+
+// si64UnaryOperators - only neg and abs are meaningful for integers
+// nil entries indicate unsupported operations for this type
+var si64UnaryOperators = [maxʘUnaryOperator]*si64UnaryOperator{
+	&absi64, // absOpType
+	nil,     // signOpType
+	nil,     // ceilOpType
+	nil,     // floorOpType
+	nil,     // sinOpType
+	nil,     // cosOpType
+	nil,     // expOpType
+	nil,     // lnOpType
+	nil,     // log2OpType
+	&negi64, // negOpType
+	nil,     // squareOpType
+	nil,     // sqrtOpType
+	nil,     // inverseOpType
+	nil,     // inverseSqrtOpType
+	nil,     // cubeOpType
+	nil,     // tanhOpType
+	nil,     // sigmoidOpType
+	nil,     // log1pOpType
+	nil,     // expm1OpType
+	nil,     // softplusOpType
+}
+
+// si32UnaryOperators - only neg and abs are meaningful for integers
+var si32UnaryOperators = [maxʘUnaryOperator]*si32UnaryOperator{
+	&absi32, // absOpType
+	nil,     // signOpType
+	nil,     // ceilOpType
+	nil,     // floorOpType
+	nil,     // sinOpType
+	nil,     // cosOpType
+	nil,     // expOpType
+	nil,     // lnOpType
+	nil,     // log2OpType
+	&negi32, // negOpType
+	nil,     // squareOpType
+	nil,     // sqrtOpType
+	nil,     // inverseOpType
+	nil,     // inverseSqrtOpType
+	nil,     // cubeOpType
+	nil,     // tanhOpType
+	nil,     // sigmoidOpType
+	nil,     // log1pOpType
+	nil,     // expm1OpType
+	nil,     // softplusOpType
 }

--- a/operatorPointwise_unary_gen.go
+++ b/operatorPointwise_unary_gen.go
@@ -97,3 +97,25 @@ func (f *sf64UnaryOperator) unaryOpType() ʘUnaryOperatorType {
 	return maxʘUnaryOperator
 }
 func (f *sf64UnaryOperator) String() string { return f.unaryOpType().String() }
+
+func (f *si64UnaryOperator) unaryOpType() ʘUnaryOperatorType {
+	switch f {
+	case &absi64:
+		return absOpType
+	case &negi64:
+		return negOpType
+	}
+	return maxʘUnaryOperator
+}
+func (f *si64UnaryOperator) String() string { return f.unaryOpType().String() }
+
+func (f *si32UnaryOperator) unaryOpType() ʘUnaryOperatorType {
+	switch f {
+	case &absi32:
+		return absOpType
+	case &negi32:
+		return negOpType
+	}
+	return maxʘUnaryOperator
+}
+func (f *si32UnaryOperator) String() string { return f.unaryOpType().String() }


### PR DESCRIPTION
`Neg()` does not support int32/int64 — this adds it.