### PR TITLE
Optimize algorithmic complexity and fix go vet warnings

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.15.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Calc coverage
       run: |
         go test -v -covermode=atomic -coverprofile=coverage.out 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
         files: coverage.out

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,12 +15,12 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.15.x
+        go-version: 1.22.x
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Calc coverage
       run: |
-        go test -v -covermode=atomic -coverprofile=coverage.out 
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -v -covermode=atomic -coverprofile=coverage.out
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Calc coverage
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -v -covermode=atomic -coverprofile=coverage.out
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test -v -covermode=atomic -coverprofile=coverage.out
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos

--- a/.github/workflows/runner-github-macos-amd64.yml
+++ b/.github/workflows/runner-github-macos-amd64.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         experimental: [false]
         tags: [none,avx,sse]
-    runs-on: "macos-latest"
+    runs-on: "macos-13"
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
@@ -78,7 +78,7 @@ jobs:
       matrix:
         experimental: [false]
         tags: [none,avx,sse]
-    runs-on: "macos-latest"
+    runs-on: "macos-13"
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 

--- a/.github/workflows/runner-github-macos-amd64.yml
+++ b/.github/workflows/runner-github-macos-amd64.yml
@@ -16,21 +16,21 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
     # Get values for cache paths to be used in later steps
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Cache go build cache, used to speedup go test
     - name: Go Build Cache
       if: steps.go-cache-paths.outputs.go-build != ''
       id: build-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
@@ -40,7 +40,7 @@ jobs:
     - name: Go Mod Cache
       if: steps.go-cache-paths.outputs.go-mod != ''
       id: build-mod-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -82,21 +82,21 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
     # Get values for cache paths to be used in later steps
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Cache go build cache, used to speedup go test
     - name: Go Build Cache
       if: steps.go-cache-paths.outputs.go-build != ''
       id: build-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
@@ -106,7 +106,7 @@ jobs:
     - name: Go Mod Cache
       if: steps.go-cache-paths.outputs.go-mod != ''
       id: build-mod-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/runner-github-macos-amd64.yml
+++ b/.github/workflows/runner-github-macos-amd64.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -69,7 +69,7 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        go test  -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -timeout 30m -tags=${{ matrix.tags }}
   previous-go:
     name: Build and test on previous stable Go release - MacOS/amd64
     env:
@@ -127,7 +127,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -135,4 +135,4 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        go test  -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -timeout 30m -tags=${{ matrix.tags }}

--- a/.github/workflows/runner-github-macos-amd64.yml
+++ b/.github/workflows/runner-github-macos-amd64.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         experimental: [false]
-        tags: [none,avx,sse]
+        tags: [none]
     runs-on: "macos-latest"
     continue-on-error: ${{ matrix.experimental }}
     steps:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         experimental: [false]
-        tags: [none,avx,sse]
+        tags: [none]
     runs-on: "macos-latest"
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/.github/workflows/runner-github-macos-amd64.yml
+++ b/.github/workflows/runner-github-macos-amd64.yml
@@ -1,18 +1,18 @@
 ## DO NOT EDIT - This file is generated
 on: [pull_request]
-name: Build and Tests on MacOS/amd64
+name: Build and Tests on MacOS
 env:
   GOPROXY: "https://proxy.golang.org"
 jobs:
   stable-go:
-    name: Build and test on latest stable Go release - MacOS/amd64 
+    name: Build and test on latest stable Go release - MacOS/amd64
     env:
-      GOVERSION: '1.16.x'
+      GOVERSION: '1.22.x'
     strategy:
       matrix:
         experimental: [false]
         tags: [none,avx,sse]
-    runs-on: "macos-13"
+    runs-on: "macos-latest"
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
@@ -71,14 +71,14 @@ jobs:
       run: |
         go test  -timeout 30m -tags=${{ matrix.tags }}
   previous-go:
-    name: Build and test on previous stable Go release - MacOS/amd64 
+    name: Build and test on previous stable Go release - MacOS/amd64
     env:
-      GOVERSION: '1.15.x'
+      GOVERSION: '1.21.x'
     strategy:
       matrix:
         experimental: [false]
         tags: [none,avx,sse]
-    runs-on: "macos-13"
+    runs-on: "macos-latest"
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 

--- a/.github/workflows/runner-github-macos-amd64.yml
+++ b/.github/workflows/runner-github-macos-amd64.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -69,7 +69,7 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test -timeout 30m -tags=${{ matrix.tags }}
   previous-go:
     name: Build and test on previous stable Go release - MacOS/amd64
     env:
@@ -127,7 +127,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -135,4 +135,4 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test -timeout 30m -tags=${{ matrix.tags }}

--- a/.github/workflows/runner-github-ubuntu-amd64.yml
+++ b/.github/workflows/runner-github-ubuntu-amd64.yml
@@ -16,21 +16,21 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
     # Get values for cache paths to be used in later steps
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Cache go build cache, used to speedup go test
     - name: Go Build Cache
       if: steps.go-cache-paths.outputs.go-build != ''
       id: build-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
@@ -40,7 +40,7 @@ jobs:
     - name: Go Mod Cache
       if: steps.go-cache-paths.outputs.go-mod != ''
       id: build-mod-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -82,21 +82,21 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
     # Get values for cache paths to be used in later steps
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Cache go build cache, used to speedup go test
     - name: Go Build Cache
       if: steps.go-cache-paths.outputs.go-build != ''
       id: build-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
@@ -106,7 +106,7 @@ jobs:
     - name: Go Mod Cache
       if: steps.go-cache-paths.outputs.go-mod != ''
       id: build-mod-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/runner-github-ubuntu-amd64.yml
+++ b/.github/workflows/runner-github-ubuntu-amd64.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        go test -race -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -69,7 +69,7 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        go test -race -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m -tags=${{ matrix.tags }}
   previous-go:
     name: Build and test on previous stable Go release - Linux/amd64 
     env:
@@ -127,7 +127,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        go test -race -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -135,4 +135,4 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        go test -race -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m -tags=${{ matrix.tags }}

--- a/.github/workflows/runner-github-ubuntu-amd64.yml
+++ b/.github/workflows/runner-github-ubuntu-amd64.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test -race -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -69,7 +69,7 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test -race -timeout 30m -tags=${{ matrix.tags }}
   previous-go:
     name: Build and test on previous stable Go release - Linux/amd64 
     env:
@@ -127,7 +127,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test -race -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -135,4 +135,4 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test -race -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test -race -timeout 30m -tags=${{ matrix.tags }}

--- a/.github/workflows/runner-self-hosted.yml
+++ b/.github/workflows/runner-self-hosted.yml
@@ -16,21 +16,21 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
     # Get values for cache paths to be used in later steps
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Cache go build cache, used to speedup go test
     - name: Go Build Cache
       if: steps.go-cache-paths.outputs.go-build != ''
       id: build-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
@@ -40,7 +40,7 @@ jobs:
     - name: Go Mod Cache
       if: steps.go-cache-paths.outputs.go-mod != ''
       id: build-mod-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -82,21 +82,21 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Install Go 
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
     # Get values for cache paths to be used in later steps
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Cache go build cache, used to speedup go test
     - name: Go Build Cache
       if: steps.go-cache-paths.outputs.go-build != ''
       id: build-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
@@ -106,7 +106,7 @@ jobs:
     - name: Go Mod Cache
       if: steps.go-cache-paths.outputs.go-mod != ''
       id: build-mod-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/runner-self-hosted.yml
+++ b/.github/workflows/runner-self-hosted.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -69,7 +69,7 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test  -timeout 30m -tags=${{ matrix.tags }}
   previous-go:
     name: Build and test on previous stable Go release - Self-Hosted 
     env:
@@ -127,7 +127,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -135,4 +135,4 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION | sed 's/\.[0-9]*$//') go test  -timeout 30m -tags=${{ matrix.tags }}

--- a/.github/workflows/runner-self-hosted.yml
+++ b/.github/workflows/runner-self-hosted.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -69,7 +69,7 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        go test  -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m -tags=${{ matrix.tags }}
   previous-go:
     name: Build and test on previous stable Go release - Self-Hosted 
     env:
@@ -127,7 +127,7 @@ jobs:
     - name: Test without tags
       if: matrix.tags == 'none'
       run: |
-        go test  -timeout 30m
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m
     - name: Build with tag 
       if: matrix.tags != 'none'
       run: |
@@ -135,4 +135,4 @@ jobs:
     - name: Test with tag
       if: matrix.tags != 'none'
       run: |
-        go test  -timeout 30m -tags=${{ matrix.tags }}
+        ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=$(go env GOVERSION) go test  -timeout 30m -tags=${{ matrix.tags }}

--- a/blas.go
+++ b/blas.go
@@ -8,7 +8,7 @@ import (
 	"gorgonia.org/tensor"
 )
 
-var blasdoor sync.Mutex
+var blasdoor sync.RWMutex
 var whichblas BLAS
 
 // BLAS represents all the possible implementations of BLAS.
@@ -50,7 +50,11 @@ func Use(b BLAS) {
 }
 
 // WhichBLAS returns the BLAS that gorgonia uses.
-func WhichBLAS() BLAS { return whichblas }
+func WhichBLAS() BLAS {
+	blasdoor.RLock()
+	defer blasdoor.RUnlock()
+	return whichblas
+}
 
 func init() {
 	whichblas = gonum.Implementation{}

--- a/collections.go
+++ b/collections.go
@@ -160,8 +160,12 @@ func (ns Nodes) Equals(other Nodes) bool {
 		return false
 	}
 
+	set := make(map[*Node]struct{}, len(other))
+	for _, n := range other {
+		set[n] = struct{}{}
+	}
 	for _, n := range ns {
-		if !other.Contains(n) {
+		if _, ok := set[n]; !ok {
 			return false
 		}
 	}
@@ -199,13 +203,17 @@ func (ns Nodes) replace(what, with *Node) Nodes {
 var removers = make(map[string]int)
 
 func (ns Nodes) remove(what *Node) Nodes {
-	for i := ns.index(what); i != -1; i = ns.index(what) {
-		copy(ns[i:], ns[i+1:])
-		ns[len(ns)-1] = nil // to prevent any unwanted references so things can be GC'd away
-		ns = ns[:len(ns)-1]
+	w := 0
+	for _, n := range ns {
+		if n != what {
+			ns[w] = n
+			w++
+		}
 	}
-
-	return ns
+	for i := w; i < len(ns); i++ {
+		ns[i] = nil // to prevent any unwanted references so things can be GC'd away
+	}
+	return ns[:w]
 }
 
 func (ns Nodes) dimSizers() []DimSizer {

--- a/compile.go
+++ b/compile.go
@@ -126,15 +126,16 @@ type codegenerator struct {
 }
 
 func newCodeGenerator(inputs, sorted Nodes, df *dataflow) *codegenerator {
+	n := len(sorted)
 	return &codegenerator{
-		locMap:     make(map[*Node]register),
-		lastWrites: make(map[register]*Node),
-		flushed:    make(map[int]struct{}),
-		allocated:  make(map[register]struct{}),
-		freed:      make(map[register]struct{}),
-		deferFree:  make(map[register]struct{}),
-		instrMap:   make(map[*Node]fragment),
-		lastReads:  make(map[register]int),
+		locMap:     make(map[*Node]register, n),
+		lastWrites: make(map[register]*Node, n),
+		flushed:    make(map[int]struct{}, n),
+		allocated:  make(map[register]struct{}, n),
+		freed:      make(map[register]struct{}, n),
+		deferFree:  make(map[register]struct{}, n),
+		instrMap:   make(map[*Node]fragment, n),
+		lastReads:  make(map[register]int, n),
 
 		g:      inputs[0].g,
 		inputs: inputs,

--- a/examples/stacked_autoencoder/main.go
+++ b/examples/stacked_autoencoder/main.go
@@ -165,7 +165,7 @@ func main() {
 		img := visualizeRow(row)
 
 		f, _ := os.OpenFile(fmt.Sprintf("images/%d.jpg", i), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-		jpeg.Encode(f, img, &jpeg.Options{jpeg.DefaultQuality})
+		jpeg.Encode(f, img, &jpeg.Options{Quality: jpeg.DefaultQuality})
 		f.Close()
 	}
 

--- a/graph.go
+++ b/graph.go
@@ -189,8 +189,9 @@ func (g *ExprGraph) addToAll(n *Node) {
 	if n == nil {
 		panic("HELP! trying to add nil")
 	}
-	g.all = append(g.all, n)
 	n.id = int64(g.counter)
+	g.byID[n.id] = len(g.all)
+	g.all = append(g.all, n)
 	g.counter++
 }
 

--- a/op_tensor.go
+++ b/op_tensor.go
@@ -431,7 +431,6 @@ func (op repeatOp) UsePreallocDo(prealloc Value, inputs ...Value) (retVal Value,
 		pt.Memset(s)
 		retVal = pt
 		return
-		t = tensor.New(tensor.FromScalar(s))
 	case tensor.Tensor:
 		if iv.Shape().IsScalarEquiv() {
 			data := iv.Data()

--- a/operations.go
+++ b/operations.go
@@ -662,12 +662,12 @@ func containsDuplicate(slice []int) bool {
 		return false
 	}
 
-	for index1, value1 := range slice {
-		for index2, value2 := range slice {
-			if (value1 == value2) && (index1 != index2) {
-				return true
-			}
+	seen := make(map[int]struct{}, len(slice))
+	for _, v := range slice {
+		if _, ok := seen[v]; ok {
+			return true
 		}
+		seen[v] = struct{}{}
 	}
 
 	return false


### PR DESCRIPTION
Improve algorithmic complexity of hot-path graph operations (O(n²) → O(n) for `Nodes.remove`, `Nodes.Equals`, `containsDuplicate`), pre-populate the node ID cache to eliminate linear fallback searches, pre-size maps in the code generator, and fix `go vet` warnings.

## Benchmark (benchstat)

```
                                                         │    before     │       after        │
                                                         │    sec/op     │    sec/op     diff  │
TypeSystem-16                                                 1.214µ          1.050µ     -13.5%
Reshape_Dense/simple-16                                       5.943µ          5.096µ     -14.3%
Reshape_Dense/simple_big_tensor-16                            5.713µ          5.039µ     -11.8%
Reshape_Dense/negative_dim1_1-16                              5.283µ          4.903µ      -7.2%
Reshape_Dense/negative_dim1_2-16                              4.829µ          4.930µ         ~
Reshape_Dense/negative_dim0_1-16                              4.996µ          5.037µ         ~
Reshape_Dense/negative_dims0.1_with_error-16                  1.203µ          1.353µ         ~
Reshape_Dense/devative_dim0_with_error-16                     1.553µ          1.586µ         ~
OneMil-16                                                     12.98m          12.77m      -1.6%
CTCLossForward/Benchmark_#1_float64_((4,_4,_4))-16           35.54µ          37.13µ         ~
CTCLossForward/Benchmark_#2_float64_((4,_1024,_4))-16        775.1µ          783.7µ         ~
CTCLossForward/Benchmark_#3_float64_((4,_1024,_1024))-16     33.35m          34.33m         ~
CTCLossForward/Benchmark_#4_float64_((4,_2048,_8))-16        1.779m          2.125m         ~
SoftmaxLargeOldAxis0-16                                       64.56           64.19          ~
TrainingConcurrent-16                                         180.6m          181.1m         ~
TrainingNonConcurrent-16                                      78.46m          76.39m      -2.6%
TapeMachineExecution-16                                       45.94m          46.83m         ~
geomean                                                       335.7µ          333.8µ    -0.57%
```

