### PR TITLE
Fix OverwritesInput metadata for ops that allocate new values

### DIFF
--- a/op_reduction.go
+++ b/op_reduction.go
@@ -165,8 +165,8 @@ func (op maxOp) Do(inputs ...Value) (retVal Value, err error) {
 	return reductionDo(op, "max", (*tensor.Dense).Max, op.along, inputs...)
 }
 
-func (op maxOp) ReturnsPtr() bool     { return true }
-func (op maxOp) OverwritesInput() int { return 0 }
+func (op maxOp) ReturnsPtr() bool     { return false }
+func (op maxOp) OverwritesInput() int { return -1 }
 func (op maxOp) CallsExtern() bool    { return false }
 
 func (op maxOp) WriteHash(h hash.Hash) {
@@ -343,8 +343,8 @@ func (op sumOp) Do(inputs ...Value) (retVal Value, err error) {
 	return reductionDo(op, "sum", (*tensor.Dense).Sum, op.along, inputs...)
 }
 
-func (op sumOp) ReturnsPtr() bool      { return true }
-func (op sumOp) OverwritesInput() int  { return 0 }
+func (op sumOp) ReturnsPtr() bool      { return false }
+func (op sumOp) OverwritesInput() int  { return -1 }
 func (op sumOp) CallsExtern() bool     { return false }
 func (op sumOp) WriteHash(h hash.Hash) { fmt.Fprintf(h, "sum%v->%v", op.along, op.inputShape) }
 func (op sumOp) Hashcode() uint32      { return simpleHash(op) }

--- a/op_tensor.go
+++ b/op_tensor.go
@@ -963,9 +963,9 @@ func (op transposeOp) Do(inputs ...Value) (retVal Value, err error) {
 	// t.UT()
 }
 
-func (op transposeOp) ReturnsPtr() bool     { return true }
+func (op transposeOp) ReturnsPtr() bool     { return false }
 func (op transposeOp) CallsExtern() bool    { return false }
-func (op transposeOp) OverwritesInput() int { return 0 }
+func (op transposeOp) OverwritesInput() int { return -1 }
 
 func (op transposeOp) WriteHash(h hash.Hash) {
 	h.Write([]byte("transposeOp"))
@@ -1188,9 +1188,9 @@ func (op reshapeOp) Do(vals ...Value) (Value, error) {
 	}
 }
 
-func (op reshapeOp) ReturnsPtr() bool     { return true }
+func (op reshapeOp) ReturnsPtr() bool     { return false }
 func (op reshapeOp) CallsExtern() bool    { return false }
-func (op reshapeOp) OverwritesInput() int { return 0 }
+func (op reshapeOp) OverwritesInput() int { return -1 }
 func (op reshapeOp) WriteHash(h hash.Hash) {
 	h.Write([]byte("reshapeOp"))
 	fmt.Fprintf(h, "from: %v, dims: %v", op.from, op.to)


### PR DESCRIPTION
transposeOp, reshapeOp, maxOp, and sumOp all declared OverwritesInput() == 0 and ReturnsPtr() == true, telling the register allocator they modify their input in-place. In reality, their Do() methods allocate new values:

- transposeOp.Do() calls tensor.Transpose() which allocates via SafeT
- reshapeOp.Do() calls ShallowClone() creating a new tensor header
- maxOp/sumOp.Do() call reductionDo() which returns new tensors

This mismatch caused the register allocator to share input/output registers for these ops. While not currently causing failures (the liveness analysis prevents reuse of live registers), it violates the OverwritesInput contract and could amplify future liveness bugs.

Ops that correctly declare OverwritesInput >= 0 are unchanged:
- elemBinOp: has UsePreallocDo that writes into preallocated memory
- elemUnaryOp: has UnsafeDo that modifies in-place
- repeatOp: has UsePreallocDo + CallsExtern=true
- sliceIncrOp: has UsePreallocDo + CallsExtern=true