### PR TITLE
Fix CSE hash collision in value numbering

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -35,7 +35,7 @@ func (df *dataflow) vn(n *Node) (retVal *Node, unique bool) {
 
 	node, ok := df.uniques[n.Hashcode()]
 
-	if ok {
+	if ok && nodeEq(n, node) {
 		return node, false
 	}
 


### PR DESCRIPTION
The value numbering function vn() used only the 32-bit FNV hash to determine if two nodes are equivalent for common subexpression elimination. When two different nodes had a hash collision, the second node was incorrectly treated as a duplicate of the first, causing it to share the first node's register and interval. This led to the wrong value being read at execution time.

For example, a slice op producing shape (1,1,5) could hash-collide with a MatMul producing shape (10000,1). The MatMul would be treated as equivalent to the slice op, and any consumer of the MatMul would read the slice op's value instead.

The fix adds a nodeEq check to verify actual equivalence before declaring a CSE match, consistent with how ExprGraph.AddNode already handles hash collisions.